### PR TITLE
chore: update eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,5 @@
 import antfu from '@antfu/eslint-config'
 
 export default antfu().append({
-  ignores: ['README.md'],
+  ignores: ['README.md', 'CODE_OF_CONDUCT.md', 'LICENCE'],
 })


### PR DESCRIPTION
Actually README.md is ignored in eslint config. Here we have also code of conduct and licence files which are also markdown files. That is why I thought we can ignore those as well may be. 