### PR TITLE
chore: use vite latest version in playground

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -5,6 +5,6 @@
   },
   "dependencies": {
     "fontaine": "latest",
-    "vite": "^6.0.0"
+    "vite": "latest"
   }
 }


### PR DESCRIPTION
I think may be we can use the latest version of vite in playground as well. 🤔 