### PR TITLE
perf(readMetrics): dedupe url requests

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -65,7 +65,7 @@ export async function readMetrics(_source: URL | string) {
   const source = typeof _source !== 'string' && 'href' in _source ? _source.href : _source
 
   if (source in metricCache)
-    return Promise.resolve(metricCache[source])
+    return metricCache[source]
 
   const { protocol } = parseURL(source)
   if (!protocol)

--- a/test/metrics.spec.ts
+++ b/test/metrics.spec.ts
@@ -1,0 +1,45 @@
+import * as unpack from '@capsizecss/unpack'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { readMetrics } from '../src/metrics'
+
+const mockFont = {
+  ascent: 2000,
+  descent: -500,
+  lineGap: 200,
+  unitsPerEm: 2048,
+  xWidthAvg: 1000,
+}
+
+vi.mock('@capsizecss/unpack', () => ({
+  fromFile: vi.fn(),
+  fromUrl: vi.fn(),
+}))
+
+describe('readMetrics', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should cache url requests and only make one network call for concurrent requests', async () => {
+    const url = 'https://example.com/font.ttf'
+
+    let resolvePromise: (value: any) => void
+    const delayedPromise = new Promise((resolve) => {
+      resolvePromise = resolve
+    })
+
+    vi.mocked(unpack.fromUrl).mockReturnValue(delayedPromise as Promise<any>)
+
+    const promises = Array.from({ length: 200 }, () => readMetrics(url))
+
+    resolvePromise!(mockFont)
+
+    const results = await Promise.all(promises)
+
+    expect(unpack.fromUrl).toHaveBeenCalledTimes(1)
+
+    results.forEach((result) => {
+      expect(result).toEqual(mockFont)
+    })
+  })
+})


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

fixes: https://github.com/nuxt/fonts/issues/574

**This PR:**

- [x] Adds `urlRequestCache` to cache `@capsizecss/unpack.fromUrl` requests to make sure network requests only happen once.
- [x] Adds a test for 👆

Can confirm this fixes the nuxt/fonts issue. I think it's because the same url is requested multiple times which probrably triggers some rate limit. This might explain why larger projects have higher chances to fail in fetch as more font metrics are needed.