### PR TITLE
fix: use `css-tree` to parse font families

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "@capsizecss/metrics": "^3.5.0",
     "@capsizecss/unpack": "^2.4.0",
+    "css-tree": "^3.1.0",
     "magic-regexp": "^0.10.0",
     "magic-string": "^0.30.17",
     "pathe": "^2.0.3",
@@ -56,6 +57,7 @@
   "devDependencies": {
     "@antfu/eslint-config": "4.12.0",
     "@nuxtjs/eslint-config-typescript": "latest",
+    "@types/css-tree": "^2.3.10",
     "@types/node": "22.14.1",
     "@types/serve-handler": "6.1.4",
     "@typescript-eslint/eslint-plugin": "8.31.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@capsizecss/unpack':
         specifier: ^2.4.0
         version: 2.4.0
+      css-tree:
+        specifier: ^3.1.0
+        version: 3.1.0
       magic-regexp:
         specifier: ^0.10.0
         version: 0.10.0
@@ -39,6 +42,9 @@ importers:
       '@nuxtjs/eslint-config-typescript':
         specifier: latest
         version: 12.1.0(eslint-plugin-import-x@4.10.3(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3))(eslint@9.25.1(jiti@2.4.2))(typescript@5.8.3)
+      '@types/css-tree':
+        specifier: ^2.3.10
+        version: 2.3.10
       '@types/node':
         specifier: 22.14.1
         version: 22.14.1
@@ -837,6 +843,9 @@ packages:
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
 
+  '@types/css-tree@2.3.10':
+    resolution: {integrity: sha512-WcaBazJ84RxABvRttQjjFWgTcHvZR9jGr0Y3hccPkHjFyk/a3N8EuxjKr+QfrwjoM5b1yI1Uj1i7EzOAAwBwag==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -1454,6 +1463,10 @@ packages:
 
   css-tree@2.3.1:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css-tree@3.1.0:
+    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   css-what@6.1.0:
@@ -2590,6 +2603,9 @@ packages:
 
   mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+
+  mdn-data@2.12.2:
+    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -4423,6 +4439,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/css-tree@2.3.10': {}
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
@@ -5130,6 +5148,11 @@ snapshots:
   css-tree@2.3.1:
     dependencies:
       mdn-data: 2.0.30
+      source-map-js: 1.2.1
+
+  css-tree@3.1.0:
+    dependencies:
+      mdn-data: 2.12.2
       source-map-js: 1.2.1
 
   css-what@6.1.0: {}
@@ -6625,6 +6648,8 @@ snapshots:
   mdn-data@2.0.28: {}
 
   mdn-data@2.0.30: {}
+
+  mdn-data@2.12.2: {}
 
   merge-stream@2.0.0: {}
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -188,7 +188,27 @@ describe('parseFontFace', () => {
       }`,
     )).toStrictEqual([])
   })
-  
+
+  it('should handle sources with parentheses', () => {
+    expect(parseFontFace(
+      `@font-face {
+        font-family: 'Inter';
+        font-display: swap;
+
+        src: url('./node_modules/inter-ui/Inter (web)/Inter-Regular.woff2')
+          format('woff2');
+      }`,
+    )).toMatchInlineSnapshot(`
+      [
+        {
+          "family": "Inter",
+          "index": 0,
+          "source": "./node_modules/inter-ui/Inter (web)/Inter-Regular.woff2",
+        },
+      ]
+    `)
+  })
+
   it('should handle sources without urls', () => {
     expect(parseFontFace(
       `@font-face {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -162,86 +162,46 @@ describe('readMetrics', () => {
 
 describe('parseFontFace', () => {
   it('should extract source, weight and font-family', () => {
-    const result = parseFontFace(
+    const [result] = parseFontFace(
       `@font-face {
         font-family: Roboto, "Arial Neue", sans-serif;
         src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"),
              url("/fonts/OpenSans-Regular-webfont.woff") format("woff");
         unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
       }`,
-    ).next().value
+    )
     expect(result).toMatchInlineSnapshot(`
       {
         "family": "Roboto",
+        "index": 0,
         "source": "/fonts/OpenSans-Regular-webfont.woff2",
       }
     `)
   })
 
-  it('should handle font-family set to a CSS function', () => {
-    expect(parseFontFace(`
-      @layer base {
-        :host {
-          font-family: var(
-            --default-font-family,
-            ui-sans-serif,
-            system-ui,
-            sans-serif,
-            "Apple Color Emoji",
-            "Segoe UI Emoji",
-            "Segoe UI Symbol",
-            "Noto Color Emoji"
-          );
-        }
-      }
-    `).next().value).toMatchInlineSnapshot(`[]`)
-  })
-
-  it('should handle incomplete font-faces', () => {
-    for (const result of parseFontFace(
+  it('should not extract incomplete font-faces', () => {
+    expect(parseFontFace(`@font-face {}`)).toStrictEqual([])
+    expect(parseFontFace(
       `@font-face {
-      }`,
-    )) {
-      expect(result).toMatchInlineSnapshot(`
-      {
-        "family": "",
-        "source": "",
-      }
-    `)
-    }
-    expect([
-      ...parseFontFace(
-        `@font-face {
         font-family: 'Something'
         src: url("") format("woff"), url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2");
       }`,
-      ),
-    ]).toMatchInlineSnapshot(`
+    )).toStrictEqual([])
+  })
+  
+  it('should handle sources without urls', () => {
+    expect(parseFontFace(
+      `@font-face {
+        font-family: "Arial";
+        src: local("Arial") url();
+      }`,
+    )).toMatchInlineSnapshot(`
       [
         {
-          "family": "Something'
-              src: url("") format("woff")",
-          "source": "/fonts/OpenSans-Regular-webfont.woff2",
-        },
-        {
-          "family": "",
-          "source": "",
+          "family": "Arial",
+          "index": 0,
         },
       ]
     `)
-  })
-  it('should handle sources without urls', () => {
-    for (const result of parseFontFace(
-      `@font-face {
-        src: local("Arial") url();
-      }`,
-    )) {
-      expect(result).toMatchInlineSnapshot(`
-      {
-        "family": "",
-        "source": "",
-      }
-      `)
-    }
   })
 })

--- a/test/transform.spec.ts
+++ b/test/transform.spec.ts
@@ -1,0 +1,63 @@
+import type { RollupPlugin } from 'unplugin'
+import { describe, expect, it } from 'vitest'
+import { FontaineTransform } from '../src'
+
+describe('fontaine transform', () => {
+  it('should add fallback font family to `font-family` properties', async () => {
+    expect(await transform(`
+      .foo {
+        font-family: Poppins;
+      }
+      .bar {
+        font-family: var(--font-family, Poppins);
+      }
+    `))
+      .toMatchInlineSnapshot(`
+      ".foo {
+        font-family: Poppins, "Poppins fallback";
+      }
+      .bar {
+        font-family: var(--font-family, Poppins);
+      }"
+    `)
+  })
+
+  it('should add additional @font-face declarations', async () => {
+    expect(await transform(`
+      @font-face {
+        font-family: Poppins;
+        src: url('poppins.ttf');
+      }
+    `))
+      .toMatchInlineSnapshot(`
+      "@font-face {
+        font-family: "Poppins fallback";
+        src: local("Segoe UI");
+        size-adjust: 112.7753%;
+        ascent-override: 93.1055%;
+        descent-override: 31.0352%;
+        line-gap-override: 8.8672%;
+      }
+      @font-face {
+        font-family: "Poppins fallback";
+        src: local("Arial");
+        size-adjust: 112.1577%;
+        ascent-override: 93.6182%;
+        descent-override: 31.2061%;
+        line-gap-override: 8.916%;
+      }
+      @font-face {
+        font-family: Poppins;
+        src: url('poppins.ttf');
+      }"
+    `)
+  })
+})
+
+async function transform(css: string) {
+  const plugin = FontaineTransform.rollup({
+    fallbacks: ['Arial', 'Segoe UI'],
+  }) as RollupPlugin
+  const result = await (plugin.transform as any)(css, 'test.css')
+  return result?.code.replace(/^ {6}/gm, '').trim()
+}


### PR DESCRIPTION
resolves https://github.com/unjs/fontaine/issues/446
resolves https://github.com/unjs/fontaine/issues/296