### PR TITLE
feat(fallback): add option for multiple fallback

### DIFF
--- a/packages/fontaine/README.md
+++ b/packages/fontaine/README.md
@@ -52,7 +52,15 @@ import { FontaineTransform } from 'fontaine'
 import { defineConfig } from 'astro/config'
 
 const options = {
+  // You can specify fallbacks as an array (applies to all fonts)
   fallbacks: ['BlinkMacSystemFont', 'Segoe UI', 'Helvetica Neue', 'Arial', 'Noto Sans'],
+
+  // Or as an object to configure specific fallbacks per font family
+  // fallbacks: {
+  //   Poppins: ['Helvetica Neue'],
+  //   'JetBrains Mono': ['Courier New']
+  // },
+
   // You may need to resolve assets like `/fonts/Roboto.woff2` to a particular directory
   resolvePath: id => `file:///path/to/public/dir${id}`,
   // overrideName: (originalName) => `${name} override`

--- a/packages/fontaine/test/transform.spec.ts
+++ b/packages/fontaine/test/transform.spec.ts
@@ -172,6 +172,50 @@ describe('fontaine transform', () => {
     `, { fallbacks: ['Bingle Bob the Unknown Font'] })
     expect(result).toBeUndefined()
   })
+
+  it('should use specific fallbacks for different font families', async () => {
+    expect(await transform(`
+      @font-face {
+        font-family: Poppins;
+        src: url('poppins.ttf');
+      }
+      @font-face {
+        font-family: 'JetBrains Mono';
+        src: url('jetbrains-mono.ttf');
+      }
+    `, {
+      fallbacks: {
+        'Poppins': ['Helvetica Neue'],
+        'JetBrains Mono': ['Courier New'],
+      },
+    }))
+      .toMatchInlineSnapshot(`
+        "@font-face {
+          font-family: "Poppins fallback";
+          src: local("Helvetica Neue");
+          size-adjust: 111.1111%;
+          ascent-override: 94.5%;
+          descent-override: 31.5%;
+          line-gap-override: 9%;
+        }
+        @font-face {
+          font-family: Poppins;
+          src: url('poppins.ttf');
+        }
+        @font-face {
+          font-family: "JetBrains Mono fallback";
+          src: local("Courier New");
+          size-adjust: 99.9837%;
+          ascent-override: 102.0166%;
+          descent-override: 30.0049%;
+          line-gap-override: 0%;
+        }
+        @font-face {
+          font-family: 'JetBrains Mono';
+          src: url('jetbrains-mono.ttf');
+        }"
+      `)
+  })
 })
 
 async function transform(css: string, options: Partial<FontaineTransformOptions> = {}, filename = 'test.css') {


### PR DESCRIPTION
Add support for configuring multiple font-specific fallbacks. 


**Font-specific fallbacks**: In addition to the existing array-based configuration, users can now specify different fallback stacks for each typeface using an object literal

## Usage Example

```js
// before: same fallback stack for all fonts
fallbacks: ['BlinkMacSystemFont', 'Segoe UI', 'Helvetica Neue', 'Arial']

// after: font-specific fallback stacks
fallbacks: {
	Poppins: ['Helvetica Neue'],
	'JetBrains Mono': ['Courier New']
}
```
closes #522 
