### PR TITLE
perf(fontless): implement plugin hook filter

### DIFF
--- a/packages/fontless/src/vite.ts
+++ b/packages/fontless/src/vite.ts
@@ -15,6 +15,7 @@ import { createResolver } from './resolve'
 import { storage } from './storage'
 import { resolveMinifyCssEsbuildOptions, transformCSS } from './utils'
 
+// Copied from @tailwindcss-vite
 const CSS_LANG_QUERY_RE = /&lang\.css/
 const INLINE_STYLE_ID_RE = /[?&]index=\d+\.css$/
 // Copied from vue-bundle-renderer utils

--- a/packages/fontless/src/vite.ts
+++ b/packages/fontless/src/vite.ts
@@ -74,7 +74,6 @@ export function fontless(_options?: FontlessOptions): Plugin {
       filter: {
         id: {
           include: [CSS_EXTENSIONS_RE, CSS_LANG_QUERY_RE, INLINE_STYLE_ID_RE],
-          exclude: [/.vite/],
         },
       },
       async handler(code, id) {


### PR DESCRIPTION
@danielroe 

As part of nuxt/fonts#675. Added a plugin hook filter so that only css are processed.

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
