### PR TITLE
fix(fontless): skip plugin on `vite preview`

### DIFF
--- a/packages/fontless/src/vite.ts
+++ b/packages/fontless/src/vite.ts
@@ -30,7 +30,7 @@ export function fontless(_options?: FontlessOptions): Plugin {
 
   return {
     name: 'vite-plugin-fontless',
-
+    apply: (_config, env) => !env.isPreview,
     async configResolved(config) {
       assetContext = {
         dev: config.mode === 'development',


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

The plugin seems to slow down vite startup quite a bit. For `vite preview` specifically at least, the plugin can be skipped to improve perf.
