### PR TITLE
chore(deps): update vite in fontless examples

### DIFF
--- a/packages/fontless/examples/analog-app/package.json
+++ b/packages/fontless/examples/analog-app/package.json
@@ -47,7 +47,7 @@
     "@angular/compiler-cli": "^19.0.0",
     "jsdom": "^22.0.0",
     "typescript": "~5.5.0",
-    "vite": "7.1.4",
+    "vite": "^7.1.4",
     "vite-tsconfig-paths": "^4.2.0",
     "vitest": "^2.0.0"
   }

--- a/packages/fontless/examples/qwik-app/package.json
+++ b/packages/fontless/examples/qwik-app/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-qwik": "^2.0.0-alpha.3",
     "fontless": "latest",
     "typescript": "5.4.5",
-    "vite": "7.1.4",
+    "vite": "^7.1.4",
     "vite-tsconfig-paths": "^4.2.1"
   }
 }

--- a/packages/fontless/examples/react-app/package.json
+++ b/packages/fontless/examples/react-app/package.json
@@ -26,6 +26,6 @@
     "globals": "^15.12.0",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.15.0",
-    "vite": "7.1.4"
+    "vite": "^7.1.4"
   }
 }

--- a/packages/fontless/examples/remix-app/package.json
+++ b/packages/fontless/examples/remix-app/package.json
@@ -38,7 +38,7 @@
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.4",
     "typescript": "^5.1.6",
-    "vite": "7.1.4",
+    "vite": "^7.1.4",
     "vite-tsconfig-paths": "^4.2.1"
   }
 }

--- a/packages/fontless/examples/solid-app/package.json
+++ b/packages/fontless/examples/solid-app/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "fontless": "latest",
     "typescript": "~5.6.2",
-    "vite": "7.1.4",
+    "vite": "^7.1.4",
     "vite-plugin-solid": "^2.11.0"
   }
 }

--- a/packages/fontless/examples/svelte-app/package.json
+++ b/packages/fontless/examples/svelte-app/package.json
@@ -16,6 +16,6 @@
     "svelte": "^5.15.0",
     "svelte-check": "^4.1.1",
     "typescript": "~5.6.2",
-    "vite": "7.1.4"
+    "vite": "^7.1.4"
   }
 }

--- a/packages/fontless/examples/vanilla-app/package.json
+++ b/packages/fontless/examples/vanilla-app/package.json
@@ -11,6 +11,6 @@
   "devDependencies": {
     "fontless": "latest",
     "typescript": "~5.6.2",
-    "vite": "7.1.4"
+    "vite": "^7.1.4"
   }
 }

--- a/packages/fontless/examples/vue-app/package.json
+++ b/packages/fontless/examples/vue-app/package.json
@@ -16,7 +16,7 @@
     "@vitejs/plugin-vue": "^5.2.4",
     "fontless": "latest",
     "typescript": "~5.6.2",
-    "vite": "7.1.4",
+    "vite": "^7.1.4",
     "vue-tsc": "^2.2.10"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,7 +296,7 @@ importers:
         specifier: ~5.5.0
         version: 5.5.4
       vite:
-        specifier: 7.1.4
+        specifier: ^7.1.4
         version: 7.1.4(@types/node@22.18.6)(jiti@2.6.0)(less@4.2.2)(lightningcss@1.30.1)(sass@1.85.0)(terser@5.44.0)(yaml@2.8.1)
       vite-tsconfig-paths:
         specifier: ^4.2.0
@@ -338,7 +338,7 @@ importers:
         specifier: 5.4.5
         version: 5.4.5
       vite:
-        specifier: 7.1.4
+        specifier: ^7.1.4
         version: 7.1.4(@types/node@20.14.11)(jiti@2.6.0)(less@4.2.2)(lightningcss@1.30.1)(sass@1.85.0)(terser@5.44.0)(yaml@2.8.1)
       vite-tsconfig-paths:
         specifier: ^4.2.1
@@ -387,7 +387,7 @@ importers:
         specifier: ^8.15.0
         version: 8.44.0(eslint@9.35.0(jiti@2.6.0))(typescript@5.6.3)
       vite:
-        specifier: 7.1.4
+        specifier: ^7.1.4
         version: 7.1.4(@types/node@22.18.6)(jiti@2.6.0)(less@4.2.2)(lightningcss@1.30.1)(sass@1.85.0)(terser@5.44.0)(yaml@2.8.1)
 
   packages/fontless/examples/remix-app:
@@ -460,7 +460,7 @@ importers:
         specifier: ^5.1.6
         version: 5.9.2
       vite:
-        specifier: 7.1.4
+        specifier: ^7.1.4
         version: 7.1.4(@types/node@22.18.6)(jiti@2.6.0)(less@4.2.2)(lightningcss@1.30.1)(sass@1.85.0)(terser@5.44.0)(yaml@2.8.1)
       vite-tsconfig-paths:
         specifier: ^4.2.1
@@ -479,7 +479,7 @@ importers:
         specifier: ~5.6.2
         version: 5.6.3
       vite:
-        specifier: 7.1.4
+        specifier: ^7.1.4
         version: 7.1.4(@types/node@22.18.6)(jiti@2.6.0)(less@4.2.2)(lightningcss@1.30.1)(sass@1.85.0)(terser@5.44.0)(yaml@2.8.1)
       vite-plugin-solid:
         specifier: ^2.11.0
@@ -506,7 +506,7 @@ importers:
         specifier: ~5.6.2
         version: 5.6.3
       vite:
-        specifier: 7.1.4
+        specifier: ^7.1.4
         version: 7.1.4(@types/node@22.18.6)(jiti@2.6.0)(less@4.2.2)(lightningcss@1.30.1)(sass@1.85.0)(terser@5.44.0)(yaml@2.8.1)
 
   packages/fontless/examples/vanilla-app:
@@ -518,7 +518,7 @@ importers:
         specifier: ~5.6.2
         version: 5.6.3
       vite:
-        specifier: 7.1.4
+        specifier: ^7.1.4
         version: 7.1.4(@types/node@22.18.6)(jiti@2.6.0)(less@4.2.2)(lightningcss@1.30.1)(sass@1.85.0)(terser@5.44.0)(yaml@2.8.1)
 
   packages/fontless/examples/vue-app:
@@ -537,7 +537,7 @@ importers:
         specifier: ~5.6.2
         version: 5.6.3
       vite:
-        specifier: 7.1.4
+        specifier: ^7.1.4
         version: 7.1.4(@types/node@22.18.6)(jiti@2.6.0)(less@4.2.2)(lightningcss@1.30.1)(sass@1.85.0)(terser@5.44.0)(yaml@2.8.1)
       vue-tsc:
         specifier: ^2.2.10


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

Currently, `packages/fontless/example/*/package.json` has a different vite version from the one used in `packages/fontless/package.json`. This causes plugin type-mismatch like below:

<img width="765" height="367" alt="image" src="https://github.com/user-attachments/assets/b124a1d3-5976-4b1f-a65e-3477dde106aa" />

This PR aligns vite versions to fix this.