### PR TITLE
fix(fontless): make `FontlessOptions.assets` optional

### DIFF
--- a/packages/fontless/src/types.ts
+++ b/packages/fontless/src/types.ts
@@ -101,7 +101,7 @@ export interface FontlessOptions {
     [key: string]: ProviderOption | undefined
   }
   /** Configure the way font assets are exposed */
-  assets: {
+  assets?: {
     /**
      * The baseURL where font files are served.
      * @default '/_fonts/'


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

Currently `fontless({})` causes a type error as `assets` are required:

```js
fontless({})
//       ^^
// Argument of type '{}' is not assignable to parameter of type 'FontlessOptions'.
// Property 'assets' is missing in type '{}' but required in type 'FontlessOptions'.ts(2345)
```

From what I understand, internally it deeply merges with default options and works fine, so this type restriction can be removed.