### PR TITLE
perf(fontless): use unifont storage

### DIFF
--- a/packages/fontless/src/vite.ts
+++ b/packages/fontless/src/vite.ts
@@ -46,6 +46,7 @@ export function fontless(_options?: FontlessOptions): Plugin {
       const resolveFontFaceWithOverride = await createResolver({
         options,
         providers,
+        storage,
         normalizeFontData: normalizeFontData.bind({}, assetContext),
       })
 


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

I mentioned the startup is slow https://github.com/unjs/fontaine/pull/637 and it looks like this is due to `createUnifont` and especially with `fontshare`, which has [heavy API call on startup](https://github.com/unjs/unifont/blob/9cd2020d17deaad06c49c1f4e76abafaa6bfb821/src/providers/fontshare.ts#L17). This PR fixes such repeated API calls by making use of `storage`, which is what nuxt font already does https://github.com/nuxt/fonts/blob/e7f537a0357896d34be9c17031b3178fb4e79042/src/module.ts#L85.

```sh
$ cd packages/fontless/examples/vanilla-app

# first run without cache
$ pnpm dev
...
  VITE v7.1.7  ready in 5269 ms


# 2nd run with cache
$ pnpm dev
...
  VITE v7.1.7  ready in 206 ms
```

I think this can technically cause the list of fonts that unifont is aware of to become stale on local machine unless cleaning up `node_modules`, but perhaps this is fine to start with.