### PR TITLE
fix(fontless): avoid loading woff over woff2 with google provider

### DIFF
--- a/packages/fontless/src/resolve.ts
+++ b/packages/fontless/src/resolve.ts
@@ -131,13 +131,6 @@ export async function createResolver(context: ResolverContext): Promise<Resolver
 
     const result = await unifont.resolveFont(fontFamily, defaults, [...prioritisedProviders])
     if (result) {
-      // google provider returns priority=0 for woff2 and priority=1 for woff.
-      // this filters only priority=0 to avoid loading non-optimal fonts.
-      const priorities = new Set(result.fonts.map(f => f.meta?.priority))
-      if (priorities.size > 1 && priorities.has(0)) {
-        result.fonts = result.fonts.filter(f => f.meta?.priority === 0)
-      }
-
       // Rewrite font source URLs to be proxied/local URLs
       const fonts = normalizeFontData(result.fonts)
       if (fonts.length > 0) {

--- a/packages/fontless/src/resolve.ts
+++ b/packages/fontless/src/resolve.ts
@@ -131,6 +131,13 @@ export async function createResolver(context: ResolverContext): Promise<Resolver
 
     const result = await unifont.resolveFont(fontFamily, defaults, [...prioritisedProviders])
     if (result) {
+      // google provider returns priority=0 for woff2 and priority=1 for woff.
+      // this filters only priority=0 to avoid loading non-optimal fonts.
+      const priorities = new Set(result.fonts.map(f => f.meta?.priority))
+      if (priorities.size > 1 && priorities.has(0)) {
+        result.fonts = result.fonts.filter(f => f.meta?.priority === 0)
+      }
+
       // Rewrite font source URLs to be proxied/local URLs
       const fonts = normalizeFontData(result.fonts)
       if (fonts.length > 0) {

--- a/packages/fontless/src/utils.ts
+++ b/packages/fontless/src/utils.ts
@@ -104,6 +104,10 @@ export async function transformCSS(options: FontFamilyInjectionPluginOptions, co
       }
     }
 
+    // reverse order by priority since last rule with overlapping unicode-range wins
+    // https://www.w3.org/TR/css-fonts-4/#composite-fonts
+    result.fonts.sort((a, b) => -((a.meta?.priority || 0) - (b.meta?.priority || 0)))
+
     const prefaces: string[] = []
 
     for (const font of result.fonts) {

--- a/packages/fontless/test/e2e.spec.ts
+++ b/packages/fontless/test/e2e.spec.ts
@@ -52,7 +52,10 @@ describe.each(fixtures)('e2e %s', (fixture) => {
       }
       if (fixture === 'tailwind') {
         expect(content).toContain('--font-sans:"Geist", "Geist Fallback: Arial",sans-serif')
-        expect(content).not.toContain('format(woff)')
+        const woff = content.indexOf('format(woff)')
+        const woff2 = content.indexOf('format(woff2)')
+        expect(woff >= 0 && woff2 >= 0).toBe(true)
+        expect(woff).lessThan(woff2)
       }
     }
 

--- a/packages/fontless/test/e2e.spec.ts
+++ b/packages/fontless/test/e2e.spec.ts
@@ -52,6 +52,7 @@ describe.each(fixtures)('e2e %s', (fixture) => {
       }
       if (fixture === 'tailwind') {
         expect(content).toContain('--font-sans:"Geist", "Geist Fallback: Arial",sans-serif')
+        expect(content).not.toContain('format(woff)')
       }
     }
 


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

- Closes https://github.com/unjs/fontaine/issues/656

## problem

CSS spec says the when there are multiple `@font-face` with overlapping `unicode-range`, browser picks the last one. Note that when it's not specified, it's considered as a full range.

Reference https://www.w3.org/TR/css-fonts-4/#composite-fonts

> If the unicode ranges overlap for a set of [@font-face](https://www.w3.org/TR/css-fonts-4/#at-font-face-rule) rules with the same family and style descriptor values, the rules are ordered in the reverse order they were defined; the last rule defined is the first to be checked for a given character.

## solution

This PR moves `priority: 1` before `priority: 0` in rendered css, so browser prioritizes `priority: 0` for overlapping `unicode-range`.

## alternative

Removing `priority: 1` might be also an option since woff2 only is normally considered fine. For example, `next/font` only generates woff2 https://nextjs.org/docs/app/api-reference/components/font and fontsource`'s default setup suggests woff2 https://fontsource.org/docs/getting-started/install
