### PR TITLE
perf(fontaine): bundle @capsizecss/metrics

### DIFF
--- a/packages/fontaine/build.config.ts
+++ b/packages/fontaine/build.config.ts
@@ -1,0 +1,12 @@
+import fs from 'node:fs'
+import { defineBuildConfig } from 'unbuild'
+
+export default defineBuildConfig({
+  hooks: {
+    'build:done': async function () {
+      const { entireMetricsCollection } = await import('@capsizecss/metrics/entireMetricsCollection')
+      const output = `export const entireMetricsCollection = ${JSON.stringify(entireMetricsCollection)}`
+      fs.writeFileSync('dist/capsize-font-metrics.mjs', output)
+    },
+  },
+})

--- a/packages/fontaine/package.json
+++ b/packages/fontaine/package.json
@@ -21,6 +21,9 @@
     "performance"
   ],
   "sideEffects": false,
+  "imports": {
+    "#capsize-font-metrics": "./dist/capsize-font-metrics.mjs"
+  },
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
@@ -47,7 +50,6 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@capsizecss/metrics": "^3.5.0",
     "@capsizecss/unpack": "^3.0.0",
     "css-tree": "^3.1.0",
     "magic-regexp": "^0.10.0",
@@ -57,6 +59,7 @@
     "unplugin": "^2.3.10"
   },
   "devDependencies": {
+    "@capsizecss/metrics": "^3.5.0",
     "@types/css-tree": "2.3.10",
     "@types/node": "22.18.6",
     "@types/serve-handler": "6.1.4",

--- a/packages/fontaine/src/metrics.ts
+++ b/packages/fontaine/src/metrics.ts
@@ -2,7 +2,6 @@ import type { Font } from '@capsizecss/unpack'
 import type { FontFaceMetrics } from './css'
 
 import { fileURLToPath } from 'node:url'
-import { fontFamilyToCamelCase } from '@capsizecss/metrics'
 import { fromFile, fromUrl } from '@capsizecss/unpack'
 import { parseURL } from 'ufo'
 
@@ -91,4 +90,17 @@ export async function readMetrics(_source: URL | string) {
   const filteredMetrics = filterRequiredMetrics(metrics)
   metricCache[source] = filteredMetrics
   return filteredMetrics
+}
+
+// inline `@capsizecss/metrics`
+// https://github.com/seek-oss/capsize/blob/66344699ff7759a661a78d0629375714c6f308b0/packages/metrics/src/index.ts
+function fontFamilyToCamelCase(str: string) {
+  return str
+    .split(/[\s|-]/)
+    .filter(Boolean)
+    .map(
+      (s, i) =>
+        `${s.charAt(0)[i > 0 ? 'toUpperCase' : 'toLowerCase']()}${s.slice(1)}`,
+    )
+    .join('')
 }

--- a/packages/fontaine/src/metrics.ts
+++ b/packages/fontaine/src/metrics.ts
@@ -33,7 +33,7 @@ export async function getMetricsForFamily(family: string) {
 
   try {
     const name = fontFamilyToCamelCase(family)
-    const { entireMetricsCollection } = await import('@capsizecss/metrics/entireMetricsCollection')
+    const { entireMetricsCollection } = await import('#capsize-font-metrics') as any as typeof import('@capsizecss/metrics/entireMetricsCollection')
     const metrics = entireMetricsCollection[name as keyof typeof entireMetricsCollection]
 
     /* v8 ignore next 4 */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,9 +43,6 @@ importers:
 
   packages/fontaine:
     dependencies:
-      '@capsizecss/metrics':
-        specifier: ^3.5.0
-        version: 3.5.0
       '@capsizecss/unpack':
         specifier: ^3.0.0
         version: 3.0.0
@@ -68,6 +65,9 @@ importers:
         specifier: ^2.3.10
         version: 2.3.10
     devDependencies:
+      '@capsizecss/metrics':
+        specifier: ^3.5.0
+        version: 3.5.0
       '@types/css-tree':
         specifier: 2.3.10
         version: 2.3.10


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

- Closes https://github.com/unjs/fontaine/issues/562

This PR removes `@capsizecss/metrics` from dependency by bundling `@capsizecss/metrics/entireMetricsCollection` . This greatly reduces overall installation size since `@capsizecss/metrics` includes duplicated data for different formats and many individual code split files. While the original package size is 22.5MB https://www.npmjs.com/package/@capsizecss/metrics, the bundled file is 2.6MB

```sh
$ ls -lh packages/fontaine/dist/capsize-font-metrics.mjs 
-rw-r--r-- 1 hiroshi hiroshi 2.6M Sep 29 10:16 packages/fontaine/dist/capsize-font-metrics.mjs
```

This is the same technique use by Next.js https://github.com/vercel/next.js/blob/6d318d618fae8e1a04624abb83a107a1d4df5ab2/packages/next/taskfile.js#L124-L135