### PR TITLE
fix(fontless): add immutable cache-control during dev to prevent font flashes on ssr frameworks

### DIFF
--- a/packages/fontless/src/vite.ts
+++ b/packages/fontless/src/vite.ts
@@ -91,6 +91,7 @@ export function fontless(_options?: FontlessOptions): Plugin {
             data = await fetch(url).then(r => r.arrayBuffer()).then(r => Buffer.from(r))
             await storage.setItemRaw(key, data)
           }
+          res.setHeader('Cache-Control', 'public, max-age=31536000, immutable')
           res.end(data)
         }
         catch (e) {


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

## problem

I've been testing out in some ssr frameworks (cf. https://github.com/unjs/fontaine/pull/651) and I noticed in some frameworks, the same css is loaded on ssr and on client, which causes texts to briefly flashes by going through "with font -> without font -> with font" phases (note this happens even if font is preloaded during dev).

## solution

The issue can be prevented by adding long cache to font asset, which allows browser to not request the 2nd font request.

## how to test

I manually tested on sveltekit example https://github.com/hi-ogawa/reproductions/tree/main/fontless-sveltekit with the preview release.
