### PR TITLE
fix(fontless): join url properly for default `assets.prefix`

### DIFF
--- a/packages/fontless/src/types.ts
+++ b/packages/fontless/src/types.ts
@@ -104,7 +104,7 @@ export interface FontlessOptions {
   assets?: {
     /**
      * The baseURL where font files are served.
-     * @default '/_fonts/'
+     * @default '/assets/_fonts'
      */
     prefix?: string
     /** Currently font assets are exposed as public assets as part of the build. This will be configurable in future */

--- a/packages/fontless/src/vite.ts
+++ b/packages/fontless/src/vite.ts
@@ -32,7 +32,7 @@ export function fontless(_options?: FontlessOptions): Plugin {
       assetContext = {
         dev: config.mode === 'development',
         renderedFontURLs: new Map<string, string>(),
-        assetsBaseURL: options.assets?.prefix || `/${config.build.assetsDir}/_fonts`,
+        assetsBaseURL: options.assets?.prefix || joinURL('/', config.build.assetsDir, '_fonts'),
       }
 
       const alias = Array.isArray(config.resolve.alias) ? {} : config.resolve.alias


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

## problem

Nuxt uses `assetsDir = "_nuxt/"`, which causes assets prefix to be `/_nuxt//_fonts` and seems to be breaking font loading. 

## solution

This PR uses `joinURL` to handle url joining more robustly.
