### PR TITLE
chore: ignore markdown from linting

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,7 +2,7 @@ import antfu from '@antfu/eslint-config'
 
 export default antfu()
   .append({
-    ignores: ['README.md', 'packages/*/README.md'],
+    ignores: ['*.md'],
   })
   .append({
     files: ['packages/fontless/examples/**'],


### PR DESCRIPTION
we can ignore all markdown file. there are readme.md, code_of_conduct.md. maybe we can ignore both md.