### PR TITLE
[fontless] fix(render): quote the font-format directive in font-src

### DIFF
--- a/packages/fontless/src/css/render.ts
+++ b/packages/fontless/src/css/render.ts
@@ -71,10 +71,15 @@ function renderFontSrc(sources: Exclude<FontSource, string>[]) {
   return sources.map((src) => {
     if ('url' in src) {
       let rendered = `url("${src.url}")`
-      for (const key of ['format', 'tech'] as const) {
-        if (key in src) {
-          rendered += ` ${key}(${src[key]})`
+      if (src.format) {
+        let value = src.format
+        if (!(value in extensionMap) && value !== 'collection') {
+          value = `"${value}"`
         }
+        rendered += ` format(${value})`
+      }
+      if (src.tech) {
+        rendered += ` tech(${src.tech})`
       }
       return rendered
     }

--- a/packages/fontless/test/render.spec.ts
+++ b/packages/fontless/test/render.spec.ts
@@ -36,4 +36,21 @@ describe('rendering @font-face', () => {
       }"
     `)
   })
+  it('should quote unknown src formats', () => {
+    const css = generateFontFace('Inter Variable', {
+      src: [{ url: '/inter-variable.woff2', format: 'woff2-variations' }],
+      display: 'swap',
+      style: 'normal',
+      weight: '100 900',
+    })
+    expect(css).toMatchInlineSnapshot(`
+      "@font-face {
+        font-family: 'Inter Variable';
+        src: url("/inter-variable.woff2") format("woff2-variations");
+        font-display: swap;
+        font-weight: 100 900;
+        font-style: normal;
+      }"
+    `)
+  })
 })


### PR DESCRIPTION
The spec says to use a quoted string for values not in the defined list of keywords. The font "Inter Variable" from fontsource uses "woff2-variations" as the format, which is not a known keyword.

For reference, only the following formats are allowed to be unquoted: collection, embedded-opentype, opentype, svg, truetype, woff, woff2.

[MDN Reference](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@font-face/src#format)

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering of font src declarations: unknown/unsupported formats are now emitted quoted (format("...")), and tech(...) is only included when present, ensuring generated @font-face rules match CSS expectations.
* **Tests**
  * Added a test validating @font-face output includes quoted unknown formats, preserves declaration order, and includes tech/format when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->