### PR TITLE
Add fontaine CLI entrypoint

### DIFF
--- a/packages/fontaine/README.md
+++ b/packages/fontaine/README.md
@@ -43,6 +43,16 @@ Or, with `yarn`
 yarn add -D fontaine
 ```
 
+## CLI usage
+
+You can also run fontaine directly against a CSS file:
+
+```bash
+npx fontaine ./src/styles.css ./dist/styles.css
+```
+
+If the output file is omitted, fontaine writes to `<input>.fontaine.css`.
+
 ## Usage
 
 ```js

--- a/packages/fontaine/package.json
+++ b/packages/fontaine/package.json
@@ -33,6 +33,9 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "fontaine": "./dist/cli.mjs"
+  },
   "files": [
     "dist"
   ],

--- a/packages/fontaine/src/cli.ts
+++ b/packages/fontaine/src/cli.ts
@@ -33,7 +33,7 @@ export async function transformCssFile({ input, output, ...options }: FontaineCl
     throw new Error('Fontaine transform hook is unavailable')
 
   const transformed = await transform.handler.call({} as any, source, inputPath)
-  const code = typeof transformed === 'string' ? transformed : transformed?.code || source
+  const code = typeof transformed === 'string' ? transformed : (transformed?.code ?? source)
   const outputPath = output
     ? resolve(output)
     : `${inputPath.slice(0, Math.max(0, inputPath.length - extname(inputPath).length))}.fontaine.css`
@@ -65,6 +65,12 @@ async function main() {
   }
 
   const [input, output] = args
+
+  if (args.length > 2) {
+    console.error('Too many positional arguments. Expected: fontaine <input.css> [output.css]')
+    process.exitCode = 1
+    return
+  }
 
   if (!input) {
     printHelp()

--- a/packages/fontaine/src/cli.ts
+++ b/packages/fontaine/src/cli.ts
@@ -4,11 +4,19 @@ import { basename, dirname, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { FontaineTransform, type FontaineTransformOptions } from './transform'
 
+/** Options for transforming a CSS file from the fontaine CLI or API. */
 export interface FontaineCliOptions extends Partial<FontaineTransformOptions> {
+  /** CSS file to transform. */
   input: string
+  /** Output file path. Defaults to `<input>.fontaine.css`. */
   output?: string
 }
 
+/**
+ * Transform a CSS file with Fontaine and write the generated output.
+ *
+ * @returns The resolved output path.
+ */
 export async function transformCssFile({ input, output, ...options }: FontaineCliOptions): Promise<string> {
   const inputPath = resolve(input)
   const source = readFileSync(inputPath, 'utf8')
@@ -31,6 +39,7 @@ export async function transformCssFile({ input, output, ...options }: FontaineCl
   return outputPath
 }
 
+/** Print command-line usage information. */
 function printHelp() {
   console.log(`Usage: fontaine <input.css> [output.css]
 
@@ -42,6 +51,7 @@ Arguments:
 `)
 }
 
+/** Run the Fontaine command-line interface. */
 async function main() {
   const [, , ...args] = process.argv
 

--- a/packages/fontaine/src/cli.ts
+++ b/packages/fontaine/src/cli.ts
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
+import type { FontaineTransformOptions } from './transform'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { basename, dirname, resolve } from 'node:path'
+import { basename, dirname, extname, resolve } from 'node:path'
+import process from 'node:process'
 import { pathToFileURL } from 'node:url'
-import { FontaineTransform, type FontaineTransformOptions } from './transform'
+import { FontaineTransform } from './transform'
 
 /** Options for transforming a CSS file from the fontaine CLI or API. */
 export interface FontaineCliOptions extends Partial<FontaineTransformOptions> {
@@ -32,7 +34,9 @@ export async function transformCssFile({ input, output, ...options }: FontaineCl
 
   const transformed = await transform.handler.call({} as any, source, inputPath)
   const code = typeof transformed === 'string' ? transformed : transformed?.code || source
-  const outputPath = output ? resolve(output) : inputPath.replace(/\.css$/, '.fontaine.css')
+  const outputPath = output
+    ? resolve(output)
+    : `${inputPath.slice(0, Math.max(0, inputPath.length - extname(inputPath).length))}.fontaine.css`
 
   mkdirSync(dirname(outputPath), { recursive: true })
   writeFileSync(outputPath, code)

--- a/packages/fontaine/src/cli.ts
+++ b/packages/fontaine/src/cli.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { basename, dirname, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { FontaineTransform, type FontaineTransformOptions } from './transform'
+
+export interface FontaineCliOptions extends Partial<FontaineTransformOptions> {
+  input: string
+  output?: string
+}
+
+export async function transformCssFile({ input, output, ...options }: FontaineCliOptions): Promise<string> {
+  const inputPath = resolve(input)
+  const source = readFileSync(inputPath, 'utf8')
+  const plugin = FontaineTransform.rollup({
+    fallbacks: ['Arial'],
+    ...options,
+    resolvePath: options.resolvePath || (id => pathToFileURL(resolve(dirname(inputPath), id)).toString()),
+  })
+  const transformPlugin = Array.isArray(plugin) ? plugin[0]! : plugin
+  const transform = transformPlugin.transform
+  if (!transform || typeof transform === 'string' || typeof transform === 'function')
+    throw new Error('Fontaine transform hook is unavailable')
+
+  const transformed = await transform.handler.call({} as any, source, inputPath)
+  const code = typeof transformed === 'string' ? transformed : transformed?.code || source
+  const outputPath = output ? resolve(output) : inputPath.replace(/\.css$/, '.fontaine.css')
+
+  mkdirSync(dirname(outputPath), { recursive: true })
+  writeFileSync(outputPath, code)
+  return outputPath
+}
+
+function printHelp() {
+  console.log(`Usage: fontaine <input.css> [output.css]
+
+Transforms a CSS file and writes fallback font-face rules using fontaine.
+
+Arguments:
+  input.css    CSS file to transform
+  output.css   Output path. Defaults to <input>.fontaine.css
+`)
+}
+
+async function main() {
+  const [, , ...args] = process.argv
+
+  if (args.includes('-h') || args.includes('--help')) {
+    printHelp()
+    return
+  }
+
+  const [input, output] = args
+
+  if (!input) {
+    printHelp()
+    process.exitCode = 1
+    return
+  }
+
+  if (!existsSync(input)) {
+    console.error(`Input file not found: ${input}`)
+    process.exitCode = 1
+    return
+  }
+
+  const outputPath = await transformCssFile({ input, output })
+  console.log(`Generated ${basename(outputPath)}`)
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+}

--- a/packages/fontaine/src/cli.ts
+++ b/packages/fontaine/src/cli.ts
@@ -22,10 +22,11 @@ export interface FontaineCliOptions extends Partial<FontaineTransformOptions> {
 export async function transformCssFile({ input, output, ...options }: FontaineCliOptions): Promise<string> {
   const inputPath = resolve(input)
   const source = readFileSync(inputPath, 'utf8')
+  const { fallbacks = ['Arial'], resolvePath, ...transformOptions } = options
   const plugin = FontaineTransform.rollup({
-    fallbacks: ['Arial'],
-    ...options,
-    resolvePath: options.resolvePath || (id => pathToFileURL(resolve(dirname(inputPath), id)).toString()),
+    ...transformOptions,
+    fallbacks,
+    resolvePath: resolvePath || (id => pathToFileURL(resolve(dirname(inputPath), id)).toString()),
   })
   const transformPlugin = Array.isArray(plugin) ? plugin[0]! : plugin
   const transform = transformPlugin.transform

--- a/packages/fontaine/src/index.ts
+++ b/packages/fontaine/src/index.ts
@@ -1,9 +1,8 @@
+export { transformCssFile } from './cli'
+export type { FontaineCliOptions } from './cli'
 export { generateFallbackName, generateFontFace } from './css'
 export { DEFAULT_CATEGORY_FALLBACKS, type FontCategory, resolveCategoryFallbacks } from './fallbacks'
 export type { ResolveCategoryFallbacksOptions } from './fallbacks'
 export { getMetricsForFamily, readMetrics } from './metrics'
-
-export { transformCssFile } from './cli'
-export type { FontaineCliOptions } from './cli'
 export { FontaineTransform } from './transform'
 export type { FontaineTransformOptions } from './transform'

--- a/packages/fontaine/src/index.ts
+++ b/packages/fontaine/src/index.ts
@@ -3,5 +3,7 @@ export { DEFAULT_CATEGORY_FALLBACKS, type FontCategory, resolveCategoryFallbacks
 export type { ResolveCategoryFallbacksOptions } from './fallbacks'
 export { getMetricsForFamily, readMetrics } from './metrics'
 
+export { transformCssFile } from './cli'
+export type { FontaineCliOptions } from './cli'
 export { FontaineTransform } from './transform'
 export type { FontaineTransformOptions } from './transform'

--- a/packages/fontaine/tsdown.config.ts
+++ b/packages/fontaine/tsdown.config.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/cli.ts'],
   format: ['es', 'cjs'],
   dts: {
     oxc: true,


### PR DESCRIPTION
## Summary

Adds a first CLI entrypoint for `fontaine` so the package can be used directly against a CSS file without wiring up Vite/Webpack/Rollup.

Changes:
- adds `src/cli.ts` with `fontaine <input.css> [output.css]`
- exposes the executable through `package.json` `bin`
- includes the CLI entry in `tsdown` so `dist/cli.mjs` is built with a shebang and execute bit
- exports `transformCssFile()` for programmatic usage
- documents the CLI usage in the README

## Testing

- `pnpm --filter fontaine build`
- `node packages/fontaine/dist/cli.mjs --help`
- `pnpm --filter fontaine test:types`
- `git diff --check`

Note: `pnpm --filter fontaine test:unit` currently fails locally due 12 pre-existing inline snapshot mismatches unrelated to this CLI entrypoint. The CLI build/typecheck/help-path validation above passes.

Fixes #17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line interface so users can run the tool directly (via npx or installed) to transform CSS files.
  * CLI prints a confirmation like "Generated <filename>" and defaults output to <input>.fontaine.css if none is specified.

* **Documentation**
  * Added CLI usage docs with examples and workflow for running the tool from the command line.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->