### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fontaine-monorepo",
   "preview": true,
   "type": "module",
-  "packageManager": "pnpm@10.29.3",
+  "packageManager": "pnpm@11.1.2",
   "description": "Automatic font fallback based on font metrics",
   "author": {
     "name": "Daniel Roe",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,12 +12,14 @@ overrides:
   fontless: 'workspace:*'
   unstorage: 1.17.4
   vue: 3.5.30
-ignoredBuiltDependencies:
-  - '@parcel/watcher'
-  - '@swc/core'
-  - esbuild
-  - vue-demi
 
-onlyBuiltDependencies:
-  - shadcn-docs-nuxt
-  - simple-git-hooks
+allowBuilds:
+  '@parcel/watcher': false
+  '@swc/core': false
+  esbuild: false
+  lmdb: false
+  msgpackr-extract: false
+  shadcn-docs-nuxt: true
+  sharp: false
+  simple-git-hooks: true
+  vue-demi: false


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pnpm package manager to version 11.1.2
  * Refined workspace build configuration settings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/fontaine/pull/763?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->