### PR TITLE
fix(fontless): render valid `format()` values in `@font-face` src

### DIFF
--- a/packages/fontless/src/css/render.ts
+++ b/packages/fontless/src/css/render.ts
@@ -67,14 +67,21 @@ export function parseFont(font: string): RemoteFontSource | { name: string } {
   return { name: font }
 }
 
+// https://drafts.csswg.org/css-fonts-4/#font-format-values
+const fontFormatKeywords = new Set(['collection', 'embedded-opentype', 'opentype', 'svg', 'truetype', 'woff', 'woff2'])
+
 function renderFontSrc(sources: Exclude<FontSource, string>[]) {
   return sources.map((src) => {
     if ('url' in src) {
       let rendered = `url("${src.url}")`
-      for (const key of ['format', 'tech'] as const) {
-        if (key in src) {
-          rendered += ` ${key}(${src[key]})`
-        }
+      // `format()` takes a `<font-format>` keyword, or a string for values outside
+      // that set (such as the legacy `woff2-variations`).
+      if (src.format) {
+        rendered += ` format(${fontFormatKeywords.has(src.format) ? src.format : `"${src.format}"`})`
+      }
+      // `tech()` takes `<font-tech>` keywords only — never a string.
+      if (src.tech) {
+        rendered += ` tech(${src.tech})`
       }
       return rendered
     }

--- a/packages/fontless/test/render.spec.ts
+++ b/packages/fontless/test/render.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { generateFontFace } from '../src/css/render'
+import { generateFontFace, parseFont } from '../src/css/render'
 
 describe('rendering @font-face', () => {
   it('should add declarations for `font-family`', () => {
@@ -33,6 +33,44 @@ describe('rendering @font-face', () => {
         font-weight: 400;
         font-style: italic;
         font-stretch: expanded;
+      }"
+    `)
+  })
+  it('should omit `format()` when the format is unknown', () => {
+    // `parseFont` leaves `format` undefined when the extension is not recognised,
+    // which covers cache-busted and extensionless provider URLs
+    const css = generateFontFace('Inter', {
+      src: [parseFont('/inter.woff2?v=3.19') as never, parseFont('https://fonts.example.com/l/font?kit=abc') as never],
+    })
+    expect(css).toMatchInlineSnapshot(`
+      "@font-face {
+        font-family: 'Inter';
+        src: url("/inter.woff2?v=3.19"), url("https://fonts.example.com/l/font?kit=abc");
+        font-display: swap;
+      }"
+    `)
+  })
+  it('should quote `format()` values that are not keywords', () => {
+    const css = generateFontFace('Inter', {
+      src: [{ url: '/inter.woff2', format: 'woff2-variations' }],
+    })
+    expect(css).toMatchInlineSnapshot(`
+      "@font-face {
+        font-family: 'Inter';
+        src: url("/inter.woff2") format("woff2-variations");
+        font-display: swap;
+      }"
+    `)
+  })
+  it('should render `tech()` as an unquoted keyword', () => {
+    const css = generateFontFace('Trickster', {
+      src: [{ url: '/trickster.otf', format: 'opentype', tech: 'color-COLRv1' }],
+    })
+    expect(css).toMatchInlineSnapshot(`
+      "@font-face {
+        font-family: 'Trickster';
+        src: url("/trickster.otf") format(opentype) tech(color-COLRv1);
+        font-display: swap;
       }"
     `)
   })


### PR DESCRIPTION
Fixes #772

### 🔗 Linked issue

#772

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

`renderFontSrc` could emit two kinds of invalid `src` values.

**`format(undefined)`** — `parseFont` always sets the `format` key, leaving it `undefined` when the extension isn't in `formatMap`. `renderFontSrc` guarded with `key in src`, which is `true` for a key whose value is `undefined`, so cache-busted (`/inter.woff2?v=3.19`) and extensionless (`…/l/font?kit=abc`) URLs rendered the literal `format(undefined)`.

**Unquoted non-keyword formats** — [css-fonts-4](https://drafts.csswg.org/css-fonts-4/#src-desc) defines `<font-format>` as `<string> | collection | embedded-opentype | opentype | svg | truetype | woff | woff2`, so only those seven keywords may appear bare. `unifont` drops the quotes when parsing provider CSS, so a legacy `format("woff2-variations")` round-tripped back out as invalid bare `format(woff2-variations)`.

Both are silent font failures in Safari in particular: MDN's compat data records `drop_invalid_item: false` for Safari, so it discards the **entire** `src` descriptor rather than just the offending component, leaving the `@font-face` with no usable source. Chrome only drops invalid items for `tech()`, so it isn't reliably forgiving either.

The guard now tests the value instead of key presence, and quotes format values outside the keyword set:

```ts
if (src.format) {
  rendered += ` format(${fontFormatKeywords.has(src.format) ? src.format : `"${src.format}"`})`
}
if (src.tech) {
  rendered += ` tech(${src.tech})`
}
```

`tech()` gets the same value guard — which fixes `tech(undefined)` — but deliberately stays **unquoted**: `tech(<font-tech>#)` accepts keywords only, with no string alternative, so quoting it would be invalid.

Keyword output is unchanged (`format(woff2)` still renders bare), so no existing snapshot moved.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have added tests (3 new cases in `packages/fontless/test/render.spec.ts`, covering unknown formats, non-keyword formats, and `tech()` keywords).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated `@font-face` CSS to use standards-compliant `format()` values.
  * Preserved known font formats as unquoted keywords while correctly quoting nonstandard values.
  * Continued rendering `tech()` values as unquoted keywords.

* **Tests**
  * Added coverage for standard, custom, and quoted font format values, plus `tech()` output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->