### PR TITLE
feat(fontless): support configurable cache directory or driver

### DIFF
--- a/packages/fontless/README.md
+++ b/packages/fontless/README.md
@@ -111,6 +111,12 @@ fontless({
     prefix: '/assets/_fonts'
   },
 
+  // Where font metadata and downloaded fonts are cached between builds, defaulting to
+  // `node_modules/.cache/fontless/meta`. Accepts a directory (resolved from the Vite
+  // root), `{ dir }`, an `unstorage` instance for a custom driver, or `false` to
+  // disable persistent caching.
+  cache: '.cache/fonts',
+
   // Experimental features
   experimental: {
     disableLocalFallbacks: false

--- a/packages/fontless/src/storage.ts
+++ b/packages/fontless/src/storage.ts
@@ -1,9 +1,38 @@
 import type { Storage, StorageValue } from 'unstorage'
+import type { FontlessOptions } from './types'
+
+import { dirname, resolve } from 'node:path'
+import { cwd } from 'node:process'
 import { createStorage } from 'unstorage'
 import fsDriver from 'unstorage/drivers/fs'
+import memoryDriver from 'unstorage/drivers/memory'
 
-const cacheBase = 'node_modules/.cache/fontless/meta'
+interface FontlessStorageContext {
+  /** The Vite project root, which a user-provided relative cache directory is resolved against. */
+  root?: string
+  /** Vite's resolved `cacheDir`; the default cache directory is created as a sibling of it. */
+  cacheDir?: string
+}
 
-export const storage: Storage<StorageValue> = createStorage({
-  driver: fsDriver({ base: cacheBase }),
-})
+function isStorage(cache: unknown): cache is Storage<StorageValue> {
+  return !!cache && typeof cache === 'object' && typeof (cache as Storage).getItem === 'function'
+}
+
+export function createFontlessStorage(cache?: FontlessOptions['cache'], context: FontlessStorageContext = {}): Storage<StorageValue> {
+  if (cache === false) {
+    return createStorage({ driver: memoryDriver() })
+  }
+
+  if (isStorage(cache)) {
+    return cache
+  }
+
+  const root = context.root ?? cwd()
+  const dir = typeof cache === 'string' ? cache : cache?.dir
+
+  const base = dir
+    ? resolve(root, dir)
+    : resolve(dirname(context.cacheDir ?? resolve(root, 'node_modules/.vite')), '.cache/fontless/meta')
+
+  return createStorage({ driver: fsDriver({ base }) })
+}

--- a/packages/fontless/src/types.ts
+++ b/packages/fontless/src/types.ts
@@ -1,4 +1,5 @@
 import type { FontFaceData, GoogleFamilyOptions, GoogleiconsFamilyOptions, LocalFontSource, Provider, ProviderFactory, providers, RemoteFontSource, ResolveFontOptions } from 'unifont'
+import type { Storage, StorageValue } from 'unstorage'
 
 import type { GenericCSSFamily } from './css/parse'
 
@@ -119,6 +120,16 @@ export interface FontlessOptions {
     npm?: ProviderOption
     [key: string]: ProviderOption | undefined
   }
+  /**
+   * Configure how font metadata and downloaded font files are cached between builds.
+   *
+   * - a string or `{ dir }`: cache to this directory (relative paths are resolved from the Vite root)
+   * - an `unstorage` instance: cache with your own driver
+   * - `false`: disable persistent caching (an in-memory cache is used instead)
+   *
+   * By default, fonts are cached in `node_modules/.cache/fontless/meta`, next to Vite's own cache directory.
+   */
+  cache?: false | string | { dir?: string } | Storage<StorageValue>
   /** Configure the way font assets are exposed */
   assets?: {
     /**

--- a/packages/fontless/src/vite.ts
+++ b/packages/fontless/src/vite.ts
@@ -11,7 +11,7 @@ import { normalizeFontData } from './assets'
 import { defaultOptions } from './defaults'
 import { resolveProviders } from './providers'
 import { createResolver } from './resolve'
-import { storage } from './storage'
+import { createFontlessStorage } from './storage'
 import { transformCSS } from './utils'
 
 // Copied from @tailwindcss-vite
@@ -25,11 +25,14 @@ export function fontless(_options?: FontlessOptions): Plugin {
 
   let cssTransformOptions: FontFamilyInjectionPluginOptions
   let assetContext: NormalizeFontDataContext
+  let storage: ReturnType<typeof createFontlessStorage>
 
   return {
     name: 'vite-plugin-fontless',
     apply: (_config, env) => !env.isPreview,
     async configResolved(config) {
+      storage = createFontlessStorage(_options?.cache, { root: config.root, cacheDir: config.cacheDir })
+
       assetContext = {
         dev: config.mode === 'development',
         renderedFontURLs: new Map<string, string>(),

--- a/packages/fontless/test/cache.spec.ts
+++ b/packages/fontless/test/cache.spec.ts
@@ -1,0 +1,57 @@
+import type { Storage } from 'unstorage'
+import type { FontlessOptions } from '../src/types'
+import { mkdtemp, readdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createStorage } from 'unstorage'
+import memoryDriver from 'unstorage/drivers/memory'
+import { build } from 'vite'
+import { describe, expect, it } from 'vitest'
+import { fontless } from '../src/vite'
+
+async function createFixture() {
+  const root = await mkdtemp(join(tmpdir(), 'fontless-fixture-'))
+  await writeFile(join(root, 'index.html'), '<!doctype html><html><head><link rel="stylesheet" href="/style.css"></head><body></body></html>')
+  await writeFile(join(root, 'style.css'), 'body { font-family: "Poppins", sans-serif }')
+  return root
+}
+
+async function buildFixture(root: string, cache?: FontlessOptions['cache']) {
+  await build({
+    root,
+    logLevel: 'silent',
+    build: { outDir: join(root, 'dist') },
+    plugins: [fontless({ cache, families: [{ name: 'Poppins', provider: 'google' }] })],
+  })
+}
+
+describe('cache option', () => {
+  it('should cache font metadata and assets next to vite\'s cache directory by default', { timeout: 30_000 }, async () => {
+    const root = await createFixture()
+    await buildFixture(root)
+
+    expect(await readdir(join(root, '.cache/fontless/meta'))).not.toEqual([])
+  })
+
+  it('should cache font metadata and assets in a custom directory', { timeout: 30_000 }, async () => {
+    const root = await createFixture()
+    await buildFixture(root, 'my-cache')
+
+    expect(await readdir(join(root, 'my-cache'))).not.toEqual([])
+  })
+
+  it('should use a provided unstorage instance', { timeout: 30_000 }, async () => {
+    const root = await createFixture()
+    const storage: Storage = createStorage({ driver: memoryDriver() })
+    await buildFixture(root, storage)
+
+    expect(await storage.getKeys()).not.toEqual([])
+  })
+
+  it('should not write a cache to disk when disabled', { timeout: 30_000 }, async () => {
+    const root = await createFixture()
+    await buildFixture(root, false)
+
+    expect(await readdir(root)).toEqual(['dist', 'index.html', 'style.css'])
+  })
+})

--- a/packages/fontless/test/storage.spec.ts
+++ b/packages/fontless/test/storage.spec.ts
@@ -1,0 +1,54 @@
+import { mkdtemp, readdir } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createStorage } from 'unstorage'
+import memoryDriver from 'unstorage/drivers/memory'
+import { describe, expect, it } from 'vitest'
+import { createFontlessStorage } from '../src/storage'
+
+const scratchDir = () => mkdtemp(join(tmpdir(), 'fontless-cache-'))
+
+describe('createFontlessStorage', () => {
+  it('should default to a directory alongside vite\'s cacheDir', async () => {
+    const dir = await scratchDir()
+    const storage = createFontlessStorage(undefined, { root: join(dir, 'src'), cacheDir: join(dir, 'node_modules/.vite') })
+
+    await storage.setItem('key', 'value')
+
+    expect(await readdir(join(dir, 'node_modules/.cache/fontless/meta'))).toEqual(['key'])
+  })
+
+  it('should write to a custom directory resolved from the root', async () => {
+    const root = await scratchDir()
+    const storage = createFontlessStorage('.cache/fonts', { root })
+
+    await storage.setItem('key', 'value')
+
+    expect(await readdir(join(root, '.cache/fonts'))).toEqual(['key'])
+    expect(await storage.getItem('key')).toBe('value')
+  })
+
+  it('should accept a directory via object syntax', async () => {
+    const root = await scratchDir()
+    const storage = createFontlessStorage({ dir: 'custom' }, { root })
+
+    await storage.setItem('key', 'value')
+
+    expect(await readdir(join(root, 'custom'))).toEqual(['key'])
+  })
+
+  it('should not persist to disk when cache is disabled', async () => {
+    const root = await scratchDir()
+    const storage = createFontlessStorage(false, { root })
+
+    await storage.setItem('key', 'value')
+
+    expect(await storage.getItem('key')).toBe('value')
+    expect(await readdir(root)).toEqual([])
+  })
+
+  it('should use a provided unstorage instance as-is', () => {
+    const custom = createStorage({ driver: memoryDriver() })
+    expect(createFontlessStorage(custom)).toBe(custom)
+  })
+})

--- a/packages/fontless/test/storage.spec.ts
+++ b/packages/fontless/test/storage.spec.ts
@@ -18,6 +18,24 @@ describe('createFontlessStorage', () => {
     expect(await readdir(join(dir, 'node_modules/.cache/fontless/meta'))).toEqual(['key'])
   })
 
+  it('should fall back to a node_modules cache directory when no cacheDir is given', async () => {
+    const root = await scratchDir()
+    const storage = createFontlessStorage(undefined, { root })
+
+    await storage.setItem('key', 'value')
+
+    expect(await readdir(join(root, 'node_modules/.cache/fontless/meta'))).toEqual(['key'])
+  })
+
+  it('should accept an absolute directory without a root', async () => {
+    const dir = await scratchDir()
+    const storage = createFontlessStorage(dir)
+
+    await storage.setItem('key', 'value')
+
+    expect(await readdir(dir)).toEqual(['key'])
+  })
+
   it('should write to a custom directory resolved from the root', async () => {
     const root = await scratchDir()
     const storage = createFontlessStorage('.cache/fonts', { root })


### PR DESCRIPTION
resolves https://github.com/unjs/fontaine/issues/727

this adds support for configuring the directory or cache driver handling where fonts are cached between builds (or allows totally disabling external cache)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable caching for font processing.
  * Supports default or custom cache directories, in-memory caching, disabled persistence, and existing storage providers.
  * Cache locations can be configured relative to the project or build environment.
  * Added documentation describing cache configuration options, supported formats, and defaults.

* **Bug Fixes**
  * Improved cache validation and project-relative cache handling.
  * Ensured cache settings are applied consistently during builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->