### PR TITLE
fix(fontless): respect vite base when generating font urls

### DIFF
--- a/packages/fontless/src/assets.ts
+++ b/packages/fontless/src/assets.ts
@@ -14,6 +14,11 @@ export interface NormalizeFontDataContext {
   dev: boolean
   renderedFontURLs: Map<string, string>
   assetsBaseURL: string
+  /**
+   * Public URL prefix that `assetsBaseURL` is served under, i.e. Vite's `base`.
+   * @default '/'
+   */
+  baseURL?: string
   callback?: (filename: string, url: string) => void
 }
 
@@ -38,9 +43,10 @@ export function normalizeFontData(context: NormalizeFontDataContext, faces: RawF
           context.renderedFontURLs.set(file, source.url)
           source.originalURL = source.url
 
+          const baseURL = context.baseURL || '/'
           source.url = context.dev
-            ? joinRelativeURL(context.assetsBaseURL, file)
-            : joinURL(context.assetsBaseURL, file)
+            ? joinRelativeURL(baseURL, context.assetsBaseURL, file)
+            : joinURL(baseURL, context.assetsBaseURL, file)
 
           context.callback?.(file, source.url)
         }

--- a/packages/fontless/src/vite.ts
+++ b/packages/fontless/src/vite.ts
@@ -6,7 +6,7 @@ import type { FontFamilyInjectionPluginOptions } from './utils'
 import { Buffer } from 'node:buffer'
 import { readFile } from 'node:fs/promises'
 import { defu } from 'defu'
-import { joinURL } from 'ufo'
+import { hasProtocol, joinURL } from 'ufo'
 import { normalizeFontData } from './assets'
 import { defaultOptions } from './defaults'
 import { resolveProviders } from './providers'
@@ -37,6 +37,7 @@ export function fontless(_options?: FontlessOptions): Plugin {
         dev: config.mode === 'development',
         renderedFontURLs: new Map<string, string>(),
         assetsBaseURL: options.assets?.prefix || joinURL('/', config.build.assetsDir, '_fonts'),
+        baseURL: config.base.startsWith('/') || hasProtocol(config.base) ? config.base : '/',
       }
 
       const alias = Array.isArray(config.resolve.alias) ? {} : config.resolve.alias

--- a/packages/fontless/src/vite.ts
+++ b/packages/fontless/src/vite.ts
@@ -83,7 +83,9 @@ export function fontless(_options?: FontlessOptions): Plugin {
     configureServer(server) {
       // serve font assets via middleware during dev
       // based on https://github.com/nuxt/fonts/blob/e7f537a0357896d34be9c17031b3178fb4e79042/src/assets.ts#L30
-      server.middlewares.use(assetContext.assetsBaseURL, async (req, res, next) => {
+      // Connect middlewares see the full request path, including `base`
+      const mountPath = joinURL(assetContext.baseURL || '/', assetContext.assetsBaseURL)
+      server.middlewares.use(mountPath, async (req, res, next) => {
         try {
           const filename = req.url!.slice(1)
           const url = assetContext.renderedFontURLs.get(filename)

--- a/packages/fontless/test/assets.spec.ts
+++ b/packages/fontless/test/assets.spec.ts
@@ -1,0 +1,71 @@
+import type { NormalizeFontDataContext } from '../src/assets'
+import { describe, expect, it } from 'vitest'
+import { normalizeFontData } from '../src/assets'
+
+function createContext(overrides: Partial<NormalizeFontDataContext> = {}): NormalizeFontDataContext {
+  return {
+    dev: false,
+    renderedFontURLs: new Map<string, string>(),
+    assetsBaseURL: '/assets/_fonts',
+    ...overrides,
+  }
+}
+
+function urls(context: NormalizeFontDataContext, src: string = 'https://fonts.example.com/font.woff2'): string[] {
+  const [face] = normalizeFontData(context, { src: [{ url: src, format: 'woff2' }] })
+  return face!.src.map(source => 'url' in source ? source.url : source.name)
+}
+
+describe('normalizeFontData', () => {
+  it('should serve fonts from the assets base URL by default', () => {
+    expect(urls(createContext())[0]).toMatch(/^\/assets\/_fonts\//)
+    expect(urls(createContext({ dev: true }))[0]).toMatch(/^\/assets\/_fonts\//)
+  })
+
+  it('should prefix font URLs with the base URL', () => {
+    expect(urls(createContext({ baseURL: '/build/' }))[0]).toMatch(/^\/build\/assets\/_fonts\//)
+    expect(urls(createContext({ baseURL: '/build/', dev: true }))[0]).toMatch(/^\/build\/assets\/_fonts\//)
+  })
+
+  it('should support a base URL pointing at another origin', () => {
+    expect(urls(createContext({ baseURL: 'https://cdn.example.com/build/' }))[0])
+      .toMatch(/^https:\/\/cdn\.example\.com\/build\/assets\/_fonts\//)
+  })
+
+  it('should preserve the original URL and register the rendered file', () => {
+    const context = createContext({ baseURL: '/build/' })
+    const [face] = normalizeFontData(context, { src: 'https://fonts.example.com/font.woff2' })
+    const [source] = face!.src as [{ url: string, originalURL?: string }]
+
+    expect(source.originalURL).toBe('https://fonts.example.com/font.woff2')
+    expect([...context.renderedFontURLs.values()]).toEqual(['https://fonts.example.com/font.woff2'])
+    expect(source.url.endsWith([...context.renderedFontURLs.keys()][0]!)).toBe(true)
+  })
+
+  it('should report rendered fonts to the callback with their public URL', () => {
+    const seen: Array<[string, string]> = []
+    const context = createContext({ baseURL: '/build/', callback: (file, url) => void seen.push([file, url]) })
+    normalizeFontData(context, { src: 'https://fonts.example.com/font.woff2' })
+
+    expect(seen).toHaveLength(1)
+    expect(seen[0]![1]).toBe(`/build/assets/_fonts/${seen[0]![0]}`)
+  })
+
+  it('should upgrade protocol-relative URLs to https', () => {
+    const context = createContext()
+    normalizeFontData(context, { src: '//fonts.example.com/font.woff2' })
+    expect([...context.renderedFontURLs.values()]).toEqual(['https://fonts.example.com/font.woff2'])
+  })
+
+  it('should leave local and relative font sources untouched', () => {
+    const context = createContext({ baseURL: '/build/' })
+    expect(normalizeFontData(context, { src: 'Some Local Font' })[0]!.src).toEqual([{ name: 'Some Local Font' }])
+    expect(urls(context, '/fonts/font.woff2')).toEqual(['/fonts/font.woff2'])
+    expect(context.renderedFontURLs.size).toBe(0)
+  })
+
+  it('should normalise unicode ranges to an array', () => {
+    const [face] = normalizeFontData(createContext(), { src: 'Some Local Font', unicodeRange: 'U+0000-00FF' })
+    expect(face!.unicodeRange).toEqual(['U+0000-00FF'])
+  })
+})

--- a/packages/fontless/test/base.spec.ts
+++ b/packages/fontless/test/base.spec.ts
@@ -1,0 +1,36 @@
+import { promises as fsp } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+import { join } from 'pathe'
+import { build } from 'vite'
+import { afterAll, expect, it } from 'vitest'
+
+const outDirs: string[] = []
+
+afterAll(async () => {
+  await Promise.all(outDirs.map(dir => fsp.rm(dir, { recursive: true, force: true })))
+})
+
+it('should prefix font URLs with the configured base', { timeout: 20_000 }, async () => {
+  const root = fileURLToPath(new URL('../examples/vanilla-app', import.meta.url))
+  const outDir = await fsp.mkdtemp(join(tmpdir(), 'fontless-base-'))
+  outDirs.push(outDir)
+
+  await build({
+    root,
+    base: '/build/',
+    logLevel: 'silent',
+    build: { outDir, emptyOutDir: true },
+  })
+
+  const files = await Array.fromAsync(fsp.glob('**/*', { cwd: outDir }))
+
+  const css = files.find(file => file.endsWith('.css'))!
+  expect(await readFile(join(outDir, css), 'utf-8')).toContain('url(/build/assets/_fonts')
+
+  const html = files.find(file => file.endsWith('.html'))!
+  expect(await readFile(join(outDir, html), 'utf-8')).toContain('href="/build/assets/_fonts')
+
+  expect(files.some(file => file.startsWith('assets/_fonts/') && file.endsWith('.woff2'))).toBe(true)
+})

--- a/packages/fontless/test/base.spec.ts
+++ b/packages/fontless/test/base.spec.ts
@@ -3,9 +3,11 @@ import { readFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
 import { join } from 'pathe'
-import { build } from 'vite'
+import { build, createServer } from 'vite'
 import { afterAll, expect, it } from 'vitest'
+import { fontless } from '../src'
 
+const root = fileURLToPath(new URL('../examples/vanilla-app', import.meta.url))
 const outDirs: string[] = []
 
 afterAll(async () => {
@@ -13,14 +15,15 @@ afterAll(async () => {
 })
 
 it('should prefix font URLs with the configured base', { timeout: 20_000 }, async () => {
-  const root = fileURLToPath(new URL('../examples/vanilla-app', import.meta.url))
   const outDir = await fsp.mkdtemp(join(tmpdir(), 'fontless-base-'))
   outDirs.push(outDir)
 
   await build({
     root,
     base: '/build/',
+    configFile: false,
     logLevel: 'silent',
+    plugins: [fontless({ families: [{ name: 'Poppins', preload: true }] })],
     build: { outDir, emptyOutDir: true },
   })
 
@@ -33,4 +36,40 @@ it('should prefix font URLs with the configured base', { timeout: 20_000 }, asyn
   expect(await readFile(join(outDir, html), 'utf-8')).toContain('href="/build/assets/_fonts')
 
   expect(files.some(file => file.startsWith('assets/_fonts/') && file.endsWith('.woff2'))).toBe(true)
+})
+
+it.each(['/', '/build/'])('should serve fonts under base %s in dev', { timeout: 20_000 }, async (base) => {
+  const server = await createServer({
+    root,
+    base,
+    configFile: false,
+    logLevel: 'silent',
+    plugins: [fontless()],
+    server: { host: '127.0.0.1', port: 0 },
+  })
+
+  try {
+    await server.listen()
+    const { port } = server.httpServer!.address() as { port: number }
+    const origin = `http://127.0.0.1:${port}`
+
+    // Vite serves CSS as a JS module in dev, so the CSS text is escaped
+    const css = await fetch(`${origin}${base}src/style.css`).then(r => r.text())
+    const [, fontURL] = css.match(new RegExp(`url\\(\\\\?"(${base}assets/_fonts/[^\\\\"]+)`)) || []
+    expect(fontURL, `no font URL for base ${base} in dev CSS`).toBeDefined()
+
+    // second request is served from the cache rather than refetched
+    for (const _ of [0, 1]) {
+      const font = await fetch(`${origin}${fontURL}`)
+      expect(font.status).toBe(200)
+      expect(font.headers.get('cache-control')).toContain('immutable')
+      expect((await font.arrayBuffer()).byteLength).toBeGreaterThan(0)
+    }
+
+    const unknown = await fetch(`${origin}${base}assets/_fonts/unknown.woff2`)
+    expect(unknown.headers.get('cache-control')).not.toContain('immutable')
+  }
+  finally {
+    await server.close()
+  }
 })


### PR DESCRIPTION
resolves https://github.com/unjs/fontaine/issues/756

this enables use with laravel, for example, or anywhere with a custom vite asset base

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed font asset URLs when applications are served from a configured base path.
  * Font URLs now correctly support root-relative, protocol-based, and cross-origin prefixes in development and production.
  * Preserved default asset paths when no base prefix is configured.
  * Improved font serving and caching behavior across configured base paths.

* **Tests**
  * Added coverage for CSS and HTML font URLs, emitted font files, development servers, base paths, relative sources, and Unicode ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->