### PR TITLE
fix(fontless): resolve font urls via vite's asset pipeline

### DIFF
--- a/packages/fontless/src/assets.ts
+++ b/packages/fontless/src/assets.ts
@@ -16,9 +16,21 @@ export interface NormalizeFontDataContext {
   assetsBaseURL: string
   /**
    * Public URL prefix that `assetsBaseURL` is served under, i.e. Vite's `base`.
+   *
+   * Only used when the URL is generated here rather than by `resolveAssetURL`, so it must
+   * be a path or an absolute URL; a relative base cannot be resolved without knowing the
+   * URL of the stylesheet the font is referenced from.
    * @default '/'
    */
   baseURL?: string
+  /**
+   * Return the URL to embed in generated CSS for a font that will be emitted as `file`.
+   *
+   * Used during build to hand the font to Vite's asset pipeline (so `base`, a relative
+   * base and `experimental.renderBuiltUrl` are all applied to it). Returning `undefined`
+   * falls back to joining `baseURL` and `assetsBaseURL` with the file name.
+   */
+  resolveAssetURL?: (file: string, url: string) => string | undefined
   callback?: (filename: string, url: string) => void
 }
 
@@ -44,9 +56,10 @@ export function normalizeFontData(context: NormalizeFontDataContext, faces: RawF
           source.originalURL = source.url
 
           const baseURL = context.baseURL || '/'
-          source.url = context.dev
-            ? joinRelativeURL(baseURL, context.assetsBaseURL, file)
-            : joinURL(baseURL, context.assetsBaseURL, file)
+          source.url = context.resolveAssetURL?.(file, source.url)
+            ?? (context.dev
+              ? joinRelativeURL(baseURL, context.assetsBaseURL, file)
+              : joinURL(baseURL, context.assetsBaseURL, file))
 
           context.callback?.(file, source.url)
         }

--- a/packages/fontless/src/vite.ts
+++ b/packages/fontless/src/vite.ts
@@ -49,7 +49,11 @@ export function fontless(_options?: FontlessOptions): Plugin {
     if (cached) {
       return cached
     }
-    const res = await fetch(url).then(r => r.arrayBuffer()).then(r => Buffer.from(r))
+    const response = await fetch(url)
+    if (!response.ok) {
+      throw new Error(`Could not fetch font from \`${url}\` (${response.status} ${response.statusText}).`)
+    }
+    const res = Buffer.from(await response.arrayBuffer())
     await storage.setItemRaw(key, res)
     return res
   }
@@ -129,14 +133,8 @@ export function fontless(_options?: FontlessOptions): Plugin {
             next()
             return
           }
-          const key = `data:fonts:${filename}`
-          let data = await storage.getItemRaw<Buffer>(key)
-          if (!data) {
-            data = await fetch(url).then(r => r.arrayBuffer()).then(r => Buffer.from(r))
-            await storage.setItemRaw(key, data)
-          }
           res.setHeader('Cache-Control', 'public, max-age=31536000, immutable')
-          res.end(data)
+          res.end(await loadFont(filename, url))
         }
         catch (e) {
           next(e)

--- a/packages/fontless/src/vite.ts
+++ b/packages/fontless/src/vite.ts
@@ -3,6 +3,7 @@ import type { NormalizeFontDataContext } from './assets'
 import type { FontlessOptions } from './types'
 import type { FontFamilyInjectionPluginOptions } from './utils'
 
+import { AsyncLocalStorage } from 'node:async_hooks'
 import { Buffer } from 'node:buffer'
 import { readFile } from 'node:fs/promises'
 import { defu } from 'defu'
@@ -18,6 +19,8 @@ import { transformCSS } from './utils'
 const CSS_LANG_QUERY_RE = /&lang\.css/
 const INLINE_STYLE_ID_RE = /[?&]index=\d+\.css$/
 // Copied from vue-bundle-renderer utils
+const EMPTY_SOURCE = new Uint8Array()
+
 const CSS_EXTENSIONS_RE = /\.(?:css|scss|sass|postcss|pcss|less|stylus|styl)(?:\?[^.]+)?$/
 
 export function fontless(_options?: FontlessOptions): Plugin {
@@ -26,6 +29,30 @@ export function fontless(_options?: FontlessOptions): Plugin {
   let cssTransformOptions: FontFamilyInjectionPluginOptions
   let assetContext: NormalizeFontDataContext
   let storage: ReturnType<typeof createFontlessStorage>
+
+  // `emit` is only available while a CSS module is being transformed, as it needs that
+  // transform's plugin context to emit into the right environment's bundle.
+  const buildContext = new AsyncLocalStorage<{ emit: (file: string) => string }>()
+
+  // Output file names of emitted fonts, mapped back to their key in `renderedFontURLs`
+  const fontFiles = new Map<string, string>()
+  function fontFileName(file: string) {
+    const fileName = joinURL(assetContext.assetsBaseURL, file).slice(1)
+    fontFiles.set(fileName, file)
+    return fileName
+  }
+
+  async function loadFont(file: string, url: string): Promise<Buffer> {
+    const key = `data:fonts:${file}`
+    // Use storage to cache the font data between builds
+    const cached = await storage.getItemRaw<Buffer>(key)
+    if (cached) {
+      return cached
+    }
+    const res = await fetch(url).then(r => r.arrayBuffer()).then(r => Buffer.from(r))
+    await storage.setItemRaw(key, res)
+    return res
+  }
 
   return {
     name: 'vite-plugin-fontless',
@@ -37,7 +64,16 @@ export function fontless(_options?: FontlessOptions): Plugin {
         dev: config.mode === 'development',
         renderedFontURLs: new Map<string, string>(),
         assetsBaseURL: options.assets?.prefix || joinURL('/', config.build.assetsDir, '_fonts'),
+        // A relative base (`''` or `'./'`) cannot be resolved from a URL in CSS served
+        // during dev, where every stylesheet is requested from its own path, so fall back
+        // to the server root. During build the URL is resolved by Vite instead (see
+        // `resolveAssetURL` below), which handles relative bases correctly.
         baseURL: config.base.startsWith('/') || hasProtocol(config.base) ? config.base : '/',
+        // During build, hand fonts to Vite's asset pipeline rather than writing literal
+        // URLs, so `base`, a relative base and `experimental.renderBuiltUrl` all apply.
+        resolveAssetURL: config.command === 'build'
+          ? file => buildContext.getStore()?.emit(file)
+          : undefined,
       }
 
       const alias = Array.isArray(config.resolve.alias) ? {} : config.resolve.alias
@@ -118,7 +154,15 @@ export function fontless(_options?: FontlessOptions): Plugin {
         },
       },
       async handler(code, id) {
-        const s = await transformCSS(cssTransformOptions, code, id)
+        // Font data is downloaded in `generateBundle`; rolldown requires a source up front
+        // and has no `setAssetSource`, so emit a placeholder and fill it in there
+        const emit = (file: string) => `__VITE_ASSET__${this.emitFile({
+          type: 'asset',
+          fileName: fontFileName(file),
+          source: EMPTY_SOURCE,
+        })}__`
+
+        const s = await buildContext.run({ emit }, () => transformCSS(cssTransformOptions, code, id))
 
         if (s.hasChanged()) {
           return {
@@ -128,24 +172,17 @@ export function fontless(_options?: FontlessOptions): Plugin {
         }
       },
     },
-    async generateBundle() {
-      for (const [filename, url] of assetContext.renderedFontURLs) {
-        const key = `data:fonts:${filename}`
-        // Use storage to cache the font data between builds
-        let res = await storage.getItemRaw(key)
-        if (!res) {
-          res = await fetch(url)
-            .then(r => r.arrayBuffer())
-            .then(r => Buffer.from(r))
-
-          await storage.setItemRaw(key, res)
+    async generateBundle(_options, bundle) {
+      await Promise.all(Object.values(bundle).map(async (output) => {
+        if (output.type !== 'asset') {
+          return
         }
-        this.emitFile({
-          type: 'asset',
-          fileName: joinURL(assetContext.assetsBaseURL, filename).slice(1),
-          source: res,
-        })
-      }
+        const file = fontFiles.get(output.fileName)
+        const url = file && assetContext.renderedFontURLs.get(file)
+        if (url) {
+          output.source = await loadFont(file, url)
+        }
+      }))
     },
     transformIndexHtml: {
       handler() {

--- a/packages/fontless/test/base.spec.ts
+++ b/packages/fontless/test/base.spec.ts
@@ -1,6 +1,8 @@
 import type { InlineConfig } from 'vite'
+import type { FontlessOptions } from '../src/types'
 import { promises as fsp } from 'node:fs'
 import { readFile } from 'node:fs/promises'
+import { createServer as createHTTPServer } from 'node:http'
 import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
 import { join } from 'pathe'
@@ -15,7 +17,7 @@ afterAll(async () => {
   await Promise.all(outDirs.map(dir => fsp.rm(dir, { recursive: true, force: true })))
 })
 
-async function buildApp({ plugins = [], ...config }: Omit<InlineConfig, 'root' | 'configFile' | 'logLevel'>) {
+async function buildApp({ plugins = [], ...config }: Omit<InlineConfig, 'root' | 'configFile' | 'logLevel'>, fontlessOptions: FontlessOptions = { families: [{ name: 'Poppins', preload: true }] }) {
   const outDir = await fsp.mkdtemp(join(tmpdir(), 'fontless-base-'))
   outDirs.push(outDir)
 
@@ -24,7 +26,7 @@ async function buildApp({ plugins = [], ...config }: Omit<InlineConfig, 'root' |
     root,
     configFile: false,
     logLevel: 'silent',
-    plugins: [fontless({ families: [{ name: 'Poppins', preload: true }] }), plugins],
+    plugins: [fontless(fontlessOptions), plugins],
     build: { ...config.build, outDir, emptyOutDir: true },
   })
 
@@ -155,5 +157,23 @@ it.each(['/', '/build/'])('should serve fonts under base %s in dev', { timeout: 
   }
   finally {
     await server.close()
+  }
+})
+
+it('should fail the build if a font cannot be downloaded', { timeout: 20_000 }, async () => {
+  const server = createHTTPServer((_req, res) => {
+    res.statusCode = 404
+    res.end('Not Found')
+  }).listen(0, '127.0.0.1')
+  await new Promise(resolve => server.once('listening', resolve))
+  const { port } = server.address() as { port: number }
+
+  try {
+    await expect(buildApp({}, {
+      families: [{ name: 'Poppins', src: `http://127.0.0.1:${port}/missing.woff2` }],
+    })).rejects.toThrow(/404/)
+  }
+  finally {
+    server.close()
   }
 })

--- a/packages/fontless/test/base.spec.ts
+++ b/packages/fontless/test/base.spec.ts
@@ -1,3 +1,4 @@
+import type { InlineConfig } from 'vite'
 import { promises as fsp } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -14,28 +15,111 @@ afterAll(async () => {
   await Promise.all(outDirs.map(dir => fsp.rm(dir, { recursive: true, force: true })))
 })
 
-it('should prefix font URLs with the configured base', { timeout: 20_000 }, async () => {
+async function buildApp({ plugins = [], ...config }: Omit<InlineConfig, 'root' | 'configFile' | 'logLevel'>) {
   const outDir = await fsp.mkdtemp(join(tmpdir(), 'fontless-base-'))
   outDirs.push(outDir)
 
   await build({
+    ...config,
     root,
-    base: '/build/',
     configFile: false,
     logLevel: 'silent',
-    plugins: [fontless({ families: [{ name: 'Poppins', preload: true }] })],
-    build: { outDir, emptyOutDir: true },
+    plugins: [fontless({ families: [{ name: 'Poppins', preload: true }] }), plugins],
+    build: { ...config.build, outDir, emptyOutDir: true },
   })
 
   const files = await Array.fromAsync(fsp.glob('**/*', { cwd: outDir }))
+  const read = (file: string) => readFile(join(outDir, file), 'utf-8')
 
-  const css = files.find(file => file.endsWith('.css'))!
-  expect(await readFile(join(outDir, css), 'utf-8')).toContain('url(/build/assets/_fonts')
+  return {
+    outDir,
+    files,
+    fonts: files.filter(file => file.startsWith('assets/_fonts/')),
+    css: await read(files.find(file => file.endsWith('.css'))!),
+    html: await read(files.find(file => file.endsWith('.html'))!),
+  }
+}
 
-  const html = files.find(file => file.endsWith('.html'))!
-  expect(await readFile(join(outDir, html), 'utf-8')).toContain('href="/build/assets/_fonts')
+it.each(['./', ''])('should emit font URLs relative to the CSS chunk for base %s', { timeout: 20_000 }, async (base) => {
+  const { outDir, css, fonts } = await buildApp({ base })
 
-  expect(files.some(file => file.startsWith('assets/_fonts/') && file.endsWith('.woff2'))).toBe(true)
+  const urls = [...css.matchAll(/url\((\.[^)]+\.woff2)\)/g)].map(([, url]) => url!)
+  expect(urls.length).toBeGreaterThan(0)
+
+  for (const url of urls) {
+    expect(fonts).toContain(join('assets', url))
+    expect((await fsp.stat(join(outDir, 'assets', url))).size).toBeGreaterThan(0)
+  }
+})
+
+it('should reuse fonts referenced from more than one stylesheet', { timeout: 20_000 }, async () => {
+  const extraCSS = '.extra { font-family: "Poppins", sans-serif; }'
+  const { outDir, css, fonts } = await buildApp({
+    plugins: [{
+      name: 'extra-css',
+      resolveId: id => id === 'virtual:extra.css' ? '\0virtual:extra.css' : undefined,
+      load: id => id === '\0virtual:extra.css' ? extraCSS : undefined,
+      transform: (code, id) => id.endsWith('main.ts') ? `import 'virtual:extra.css'\n${code}` : undefined,
+    }],
+  })
+
+  expect(css).toContain('.extra{')
+
+  const urls = new Set([...css.matchAll(/url\((\/assets\/_fonts\/[^)]+\.woff2)\)/g)].map(([, url]) => url!.slice(1)))
+  expect(urls.size).toBeGreaterThan(0)
+  expect(fonts).toEqual(expect.arrayContaining([...urls]))
+
+  for (const file of urls) {
+    expect((await fsp.stat(join(outDir, file))).size).toBeGreaterThan(0)
+  }
+})
+
+it('should apply experimental.renderBuiltUrl to font URLs', { timeout: 20_000 }, async () => {
+  const { css, html } = await buildApp({
+    experimental: {
+      renderBuiltUrl(filename, { hostType }) {
+        return filename.includes('_fonts') ? `https://cdn.example.com/${filename}` : { relative: hostType !== 'html' }
+      },
+    },
+  })
+
+  expect(css).toContain('url(https://cdn.example.com/assets/_fonts')
+  expect(css).not.toContain('url(/assets/_fonts')
+  expect(html).toContain('href="https://cdn.example.com/assets/_fonts')
+})
+
+it('should honour renderBuiltUrl returning a relative URL for fonts', { timeout: 20_000 }, async () => {
+  const { outDir, css, fonts } = await buildApp({
+    experimental: { renderBuiltUrl: () => ({ relative: true }) },
+  })
+
+  const urls = [...css.matchAll(/url\((\.[^)]+\.woff2)\)/g)].map(([, url]) => url!)
+  expect(urls.length).toBeGreaterThan(0)
+
+  for (const url of urls) {
+    expect(fonts).toContain(join('assets', url))
+    expect((await fsp.stat(join(outDir, 'assets', url))).size).toBeGreaterThan(0)
+  }
+})
+
+it('should prefix font URLs with the configured base', { timeout: 20_000 }, async () => {
+  const { css, html, fonts } = await buildApp({ base: '/build/' })
+
+  expect(css).toContain('url(/build/assets/_fonts')
+  expect(html).toContain('href="/build/assets/_fonts')
+  expect(fonts.some(file => file.endsWith('.woff2'))).toBe(true)
+})
+
+it('should emit font URLs from the server root by default', { timeout: 20_000 }, async () => {
+  const { outDir, css, fonts } = await buildApp({})
+
+  const urls = [...css.matchAll(/url\((\/assets\/_fonts\/[^)]+\.woff2)\)/g)].map(([, url]) => url!)
+  expect(urls.length).toBeGreaterThan(0)
+
+  for (const url of urls) {
+    expect(fonts).toContain(url.slice(1))
+    expect((await fsp.stat(join(outDir, url))).size).toBeGreaterThan(0)
+  }
 })
 
 it.each(['/', '/build/'])('should serve fonts under base %s in dev', { timeout: 20_000 }, async (base) => {


### PR DESCRIPTION
follow-up on https://github.com/unjs/fontaine/pull/787

this means things like relative urls in css files start working, plus lots more 🎉

mostly a win for consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved font asset URL handling in Vite builds, including support for custom URL resolution.
  * Font URLs now correctly respect configured base paths and deployment settings.
  * Shared font references across stylesheets are handled consistently.

* **Bug Fixes**
  * Improved development and production fallback behavior for relative font URLs.
  * Corrected absolute and relative asset URL generation during builds.
  * Builds now report an error when a font download fails.

* **Tests**
  * Added coverage for font URLs, shared assets, custom base paths, default root URLs, and failed downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->