### PR TITLE
fix(fontaine): generate fallback rules for fonts added via `@import`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ coverage
 *.env*
 .husky
 test-results
+
+# fixture package for bare-specifier resolution tests
+!packages/fontaine/test/fixtures/node_modules
+!packages/fontaine/test/fixtures/node_modules/**

--- a/packages/fontaine/src/transform.ts
+++ b/packages/fontaine/src/transform.ts
@@ -89,6 +89,67 @@ interface CssImport {
   end: number
 }
 
+const SCSS_RE = createRegExp(
+  exactly('.')
+    .and(anyOf('sass', 'scss'))
+    .and(exactly('?').and(oneOrMore(char)).optionally())
+    .at.lineEnd(),
+)
+
+/**
+ * Replaces `//` line comments with spaces, preserving offsets.
+ *
+ * css-tree has no SCSS mode and bails on the first `//` comment, parsing the
+ * remainder of the file as a single `Raw` node, which hides every at-rule that
+ * follows it.
+ */
+function blankLineComments(code: string): string {
+  let result = ''
+  let index = 0
+
+  while (index < code.length) {
+    const char = code[index]!
+
+    if (char === '"' || char === '\'') {
+      const end = code.indexOf(char, index + 1)
+      const stop = end === -1 ? code.length : end + 1
+      result += code.slice(index, stop)
+      index = stop
+      continue
+    }
+
+    if (char === '/' && code[index + 1] === '*') {
+      const end = code.indexOf('*/', index + 2)
+      const stop = end === -1 ? code.length : end + 2
+      result += code.slice(index, stop)
+      index = stop
+      continue
+    }
+
+    // `url(...)` is unquoted, so its `//` must not be treated as a comment
+    if ((char === 'u' || char === 'U') && /^url\(/i.test(code.slice(index, index + 4))) {
+      const end = code.indexOf(')', index)
+      const stop = end === -1 ? code.length : end + 1
+      result += code.slice(index, stop)
+      index = stop
+      continue
+    }
+
+    if (char === '/' && code[index + 1] === '/') {
+      const newline = code.indexOf('\n', index)
+      const stop = newline === -1 ? code.length : newline
+      result += ' '.repeat(stop - index)
+      index = stop
+      continue
+    }
+
+    result += char
+    index++
+  }
+
+  return result
+}
+
 function extractCssImports(ast: CssNode): CssImport[] {
   const imports: CssImport[] = []
   walk(ast, {
@@ -122,7 +183,8 @@ function resolveCssImport(specifier: string, importer: string): string | undefin
   try {
     if (RELATIVE_RE.test(specifier) || isAbsolute(specifier))
       return fileURLToPath(new URL(specifier, pathToFileURL(importer)))
-    return createRequire(importer).resolve(specifier)
+    // `~` prefixes a bare specifier in the webpack/sass-loader convention
+    return createRequire(importer).resolve(specifier.replace(/^~/, ''))
   }
   catch {
     return undefined
@@ -161,7 +223,7 @@ export const FontaineTransform: ReturnType<typeof createUnplugin<FontaineTransfo
         const s = new MagicString(code)
         const inserted = new Set<string>()
 
-        const ast = parse(code, { positions: true })
+        const ast = parse(SCSS_RE.test(id) ? blankLineComments(code) : code, { positions: true })
 
         const fontFaces = parseFontFace(ast).map(face => ({ ...face, importer: id, prefix: '' }))
 
@@ -182,7 +244,7 @@ export const FontaineTransform: ReturnType<typeof createUnplugin<FontaineTransfo
             if (importedCss === null)
               continue
 
-            const importedAst = parse(importedCss, { positions: true })
+            const importedAst = parse(SCSS_RE.test(resolved) ? blankLineComments(importedCss) : importedCss, { positions: true })
             for (const face of parseFontFace(importedAst)) {
               fontFaces.push({ ...face, index: insertionIndex, importer: resolved, prefix: '\n' })
             }

--- a/packages/fontaine/src/transform.ts
+++ b/packages/fontaine/src/transform.ts
@@ -1,5 +1,8 @@
+import type { CssNode } from 'css-tree'
 import type { FontCategory } from './fallbacks'
-import { pathToFileURL } from 'node:url'
+import { readFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { parse, walk } from 'css-tree'
 import { anyOf, char, createRegExp, exactly, oneOrMore } from 'magic-regexp'
 import MagicString from 'magic-string'
@@ -81,6 +84,44 @@ const RELATIVE_RE = createRegExp(
   exactly('.').or('..').and(anyOf('/', '\\')).at.lineStart(),
 )
 
+interface CssImport {
+  specifier: string
+  end: number
+}
+
+function extractCssImports(ast: CssNode): CssImport[] {
+  const imports: CssImport[] = []
+  walk(ast, {
+    visit: 'Atrule',
+    enter(node) {
+      if (node.name !== 'import' || !node.prelude)
+        return
+      walk(node.prelude, (child) => {
+        let specifier: string | undefined
+        if (child.type === 'String')
+          specifier = withoutQuotes(child.value)
+        else if (child.type === 'Url')
+          specifier = withoutQuotes(child.value)
+        if (specifier && !specifier.startsWith('http:') && !specifier.startsWith('https:') && !specifier.startsWith('data:')) {
+          imports.push({ specifier: specifier.replace(/[?#].*$/, ''), end: node.loc!.end.offset })
+        }
+      })
+    },
+  })
+  return imports
+}
+
+function resolveCssImport(specifier: string, importer: string): string | undefined {
+  try {
+    if (RELATIVE_RE.test(specifier) || isAbsolute(specifier))
+      return fileURLToPath(new URL(specifier, pathToFileURL(importer)))
+    return createRequire(importer).resolve(specifier)
+  }
+  catch {
+    return undefined
+  }
+}
+
 /**
  * Transforms CSS files to include font fallbacks.
  *
@@ -111,16 +152,48 @@ export const FontaineTransform: ReturnType<typeof createUnplugin<FontaineTransfo
       },
       async handler(code, id) {
         const s = new MagicString(code)
+        const inserted = new Set<string>()
 
         const ast = parse(code, { positions: true })
 
-        for (const { family, source, index, properties } of parseFontFace(ast)) {
+        const fontFaces = parseFontFace(ast).map(face => ({ ...face, importer: id, prefix: '' }))
+
+        if (isAbsolute(id)) {
+          const imports = extractCssImports(ast)
+          const insertionIndex = imports.length ? Math.max(...imports.map(i => i.end)) : 0
+          const seen = new Set([id])
+          const queue = imports.map(i => ({ specifier: i.specifier, importer: id, depth: 0 }))
+
+          while (queue.length) {
+            const { specifier, importer, depth } = queue.shift()!
+            const resolved = resolveCssImport(specifier, importer)
+            if (!resolved || seen.has(resolved) || !CSS_RE.test(resolved))
+              continue
+            seen.add(resolved)
+
+            const importedCss = await readFile(resolved, 'utf-8').catch(() => null)
+            if (importedCss === null)
+              continue
+
+            const importedAst = parse(importedCss, { positions: true })
+            for (const face of parseFontFace(importedAst)) {
+              fontFaces.push({ ...face, index: insertionIndex, importer: resolved, prefix: '\n' })
+            }
+            if (depth < 5) {
+              for (const nested of extractCssImports(importedAst)) {
+                queue.push({ specifier: nested.specifier, importer: resolved, depth: depth + 1 })
+              }
+            }
+          }
+        }
+
+        for (const { family, source, index, properties, importer, prefix } of fontFaces) {
           if (!supportedExtensions.some(e => source?.endsWith(e)))
             continue
           if (skipFontFaceGeneration(fallbackName(family)))
             continue
 
-          const metrics = (await getMetricsForFamily(family)) || (source && (await readMetricsFromId(source, id).catch(() => null)))
+          const metrics = (await getMetricsForFamily(family)) || (source && (await readMetricsFromId(source, importer).catch(() => null)))
 
           /* v8 ignore next 2 */
           if (!metrics)
@@ -147,8 +220,13 @@ export const FontaineTransform: ReturnType<typeof createUnplugin<FontaineTransfo
               metrics: fallbackMetrics,
               ...properties,
             })
+            const key = `${index}:${fontFace}`
+            if (inserted.has(key))
+              continue
+            inserted.add(key)
+
             cssContext.value += fontFace
-            s.appendLeft(index, fontFace)
+            s.appendLeft(index, prefix + fontFace)
           }
         }
 

--- a/packages/fontaine/src/transform.ts
+++ b/packages/fontaine/src/transform.ts
@@ -94,18 +94,25 @@ function extractCssImports(ast: CssNode): CssImport[] {
   walk(ast, {
     visit: 'Atrule',
     enter(node) {
-      if (node.name !== 'import' || !node.prelude)
+      if (node.name !== 'import' || node.prelude?.type !== 'AtrulePrelude')
         return
-      walk(node.prelude, (child) => {
-        let specifier: string | undefined
-        if (child.type === 'String')
-          specifier = withoutQuotes(child.value)
-        else if (child.type === 'Url')
-          specifier = withoutQuotes(child.value)
-        if (specifier && !specifier.startsWith('http:') && !specifier.startsWith('https:') && !specifier.startsWith('data:')) {
-          imports.push({ specifier: specifier.replace(/[?#].*$/, ''), end: node.loc!.end.offset })
+
+      let specifier: string | undefined
+      let conditional = false
+      for (const child of node.prelude.children) {
+        if (child.type === 'String' || child.type === 'Url') {
+          specifier ||= withoutQuotes(child.value)
         }
-      })
+        else if (child.type === 'MediaQueryList' || (child.type === 'Function' && child.name.toLowerCase() === 'supports')) {
+          // Fallback rules generated from a conditionally-imported file would
+          // apply unconditionally, so skip media- and supports-gated imports.
+          conditional = true
+        }
+      }
+
+      if (specifier && !conditional && !specifier.startsWith('http:') && !specifier.startsWith('https:') && !specifier.startsWith('data:')) {
+        imports.push({ specifier: specifier.replace(/[?#].*$/, ''), end: node.loc!.end.offset })
+      }
     },
   })
   return imports
@@ -162,10 +169,10 @@ export const FontaineTransform: ReturnType<typeof createUnplugin<FontaineTransfo
           const imports = extractCssImports(ast)
           const insertionIndex = imports.length ? Math.max(...imports.map(i => i.end)) : 0
           const seen = new Set([id])
-          const queue = imports.map(i => ({ specifier: i.specifier, importer: id, depth: 0 }))
+          const queue = imports.map(i => ({ specifier: i.specifier, importer: id }))
 
           while (queue.length) {
-            const { specifier, importer, depth } = queue.shift()!
+            const { specifier, importer } = queue.shift()!
             const resolved = resolveCssImport(specifier, importer)
             if (!resolved || seen.has(resolved) || !CSS_RE.test(resolved))
               continue
@@ -179,10 +186,8 @@ export const FontaineTransform: ReturnType<typeof createUnplugin<FontaineTransfo
             for (const face of parseFontFace(importedAst)) {
               fontFaces.push({ ...face, index: insertionIndex, importer: resolved, prefix: '\n' })
             }
-            if (depth < 5) {
-              for (const nested of extractCssImports(importedAst)) {
-                queue.push({ specifier: nested.specifier, importer: resolved, depth: depth + 1 })
-              }
+            for (const nested of extractCssImports(importedAst)) {
+              queue.push({ specifier: nested.specifier, importer: resolved })
             }
           }
         }

--- a/packages/fontaine/test/fixtures/imported.css
+++ b/packages/fontaine/test/fixtures/imported.css
@@ -1,5 +1,5 @@
 @font-face {
   font-family: Poppins;
-  src: url('./poppins.woff2') format('woff2');
+  src: url('./poppins.woff2') format('woff2'), url('./poppins.woff') format('woff');
   font-weight: 400;
 }

--- a/packages/fontaine/test/fixtures/imported.css
+++ b/packages/fontaine/test/fixtures/imported.css
@@ -1,0 +1,5 @@
+@font-face {
+  font-family: Poppins;
+  src: url('./poppins.woff2') format('woff2');
+  font-weight: 400;
+}

--- a/packages/fontaine/test/fixtures/nested.css
+++ b/packages/fontaine/test/fixtures/nested.css
@@ -1,0 +1,2 @@
+@import "./imported.css";
+@import "./nested.css";

--- a/packages/fontaine/test/fixtures/node_modules/@fake-fontsource/dm-sans/index.css
+++ b/packages/fontaine/test/fixtures/node_modules/@fake-fontsource/dm-sans/index.css
@@ -1,0 +1,5 @@
+@font-face {
+  font-family: 'Poppins';
+  src: url('./poppins.woff2') format('woff2');
+  font-weight: 400;
+}

--- a/packages/fontaine/test/fixtures/node_modules/@fake-fontsource/dm-sans/package.json
+++ b/packages/fontaine/test/fixtures/node_modules/@fake-fontsource/dm-sans/package.json
@@ -1,0 +1,1 @@
+{ "name": "@fake-fontsource/dm-sans", "version": "1.0.0", "main": "index.css" }

--- a/packages/fontaine/test/fixtures/with-comments.scss
+++ b/packages/fontaine/test/fixtures/with-comments.scss
@@ -1,0 +1,6 @@
+// [Poppins Variable]
+@import "~@fake-fontsource/dm-sans";
+// url(https://example.com/not-a-comment.css)
+.foo {
+  font-family: Poppins;
+}

--- a/packages/fontaine/test/transform.spec.ts
+++ b/packages/fontaine/test/transform.spec.ts
@@ -179,6 +179,33 @@ describe('fontaine transform', () => {
       `)
   })
 
+  it('should follow nested and circular CSS `@import`s without looping', async () => {
+    const cssFilename = fileURLToPath(new URL('./test.css', import.meta.url))
+    const result = await transform(`
+      @import "./fixtures/nested.css";
+      .foo {
+        font-family: Poppins;
+      }
+    `, {}, cssFilename)
+    expect(result).toContain('font-family: "Poppins fallback"')
+  })
+
+  it('should ignore conditional, remote and unresolvable CSS `@import`s', async () => {
+    const cssFilename = fileURLToPath(new URL('./test.css', import.meta.url))
+    const result = await transform(`
+      @import "./fixtures/imported.css" screen and (max-width: 600px);
+      @import "./fixtures/imported.css" supports(display: flex);
+      @import url("https://example.com/font.css");
+      @import "./fixtures/missing.css";
+      @import "@missing/pkg/font.css";
+      @import "magic-string";
+      .foo {
+        font-family: Poppins;
+      }
+    `, {}, cssFilename)
+    expect(result).not.toContain('@font-face')
+  })
+
   it('should ignore unsupported extensions', async () => {
     // @ts-expect-error not typed as mock
     fromFile.mockReset()

--- a/packages/fontaine/test/transform.spec.ts
+++ b/packages/fontaine/test/transform.spec.ts
@@ -1,5 +1,6 @@
 import type { RollupPlugin } from 'unplugin'
 import type { FontaineTransformOptions } from '../src/transform'
+import { readFile } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import { fromUrl } from '@capsizecss/unpack'
 import { fromFile } from '@capsizecss/unpack/fs'
@@ -188,6 +189,70 @@ describe('fontaine transform', () => {
       }
     `, {}, cssFilename)
     expect(result).toContain('font-family: "Poppins fallback"')
+  })
+
+  it('should resolve `~`-prefixed imports in SCSS files with line comments', async () => {
+    const scssFilename = fileURLToPath(new URL('./fixtures/with-comments.scss', import.meta.url))
+    const scss = await readFile(scssFilename, 'utf-8')
+    expect(await transform(scss, {}, scssFilename))
+      .toMatchInlineSnapshot(`
+        "// [Poppins Variable]
+        @import "~@fake-fontsource/dm-sans";
+        @font-face {
+          font-family: "Poppins fallback";
+          src: local("Segoe UI");
+          size-adjust: 112.7753%;
+          ascent-override: 93.1055%;
+          descent-override: 31.0352%;
+          line-gap-override: 8.8672%;
+          font-weight: 400;
+        }
+
+        @font-face {
+          font-family: "Poppins fallback";
+          src: local("Arial");
+          size-adjust: 112.1577%;
+          ascent-override: 93.6182%;
+          descent-override: 31.2061%;
+          line-gap-override: 8.916%;
+          font-weight: 400;
+        }
+
+        // url(https://example.com/not-a-comment.css)
+        .foo {
+          font-family: Poppins, "Poppins fallback";
+        }"
+      `)
+  })
+
+  it('should not treat `//` inside strings, comments or `url()` as a line comment', async () => {
+    expect(await transform(`
+      /* https://example.com/block.css */
+      .foo {
+        background: url(https://example.com/a.png);
+        content: 'https://example.com';
+        font-family: Poppins;
+      }
+    `, {}, 'test.scss'))
+      .toMatchInlineSnapshot(`
+        "/* https://example.com/block.css */
+        .foo {
+          background: url(https://example.com/a.png);
+          content: 'https://example.com';
+          font-family: Poppins, "Poppins fallback";
+        }"
+      `)
+  })
+
+  it('should tolerate unterminated strings, comments and `url()` in SCSS', async () => {
+    expect(await transform(`.foo { font-family: Poppins; } /* unterminated`, {}, 'test.scss'))
+      .toContain('"Poppins fallback"')
+    expect(await transform(`.foo { font-family: Poppins; } // trailing`, {}, 'test.scss'))
+      .toContain('"Poppins fallback"')
+    expect(await transform(`.foo { font-family: Poppins; background: url(unterminated`, {}, 'test.scss'))
+      .toContain('"Poppins fallback"')
+    expect(await transform(`.foo { font-family: Poppins; content: 'unterminated`, {}, 'test.scss'))
+      .toContain('"Poppins fallback"')
   })
 
   it('should ignore conditional, remote and unresolvable CSS `@import`s', async () => {

--- a/packages/fontaine/test/transform.spec.ts
+++ b/packages/fontaine/test/transform.spec.ts
@@ -143,6 +143,42 @@ describe('fontaine transform', () => {
     expect(fromFile).toHaveBeenCalledWith(fileURLToPath(new URL('./my.ttf', import.meta.url)))
   })
 
+  it('should generate @font-face rules for fonts pulled in via CSS `@import`', async () => {
+    const cssFilename = fileURLToPath(new URL('./test.css', import.meta.url))
+    expect(await transform(`
+      @import "./fixtures/imported.css";
+      .foo {
+        font-family: Poppins;
+      }
+    `, {}, cssFilename))
+      .toMatchInlineSnapshot(`
+        "@import "./fixtures/imported.css";
+        @font-face {
+          font-family: "Poppins fallback";
+          src: local("Segoe UI");
+          size-adjust: 112.7753%;
+          ascent-override: 93.1055%;
+          descent-override: 31.0352%;
+          line-gap-override: 8.8672%;
+          font-weight: 400;
+        }
+
+        @font-face {
+          font-family: "Poppins fallback";
+          src: local("Arial");
+          size-adjust: 112.1577%;
+          ascent-override: 93.6182%;
+          descent-override: 31.2061%;
+          line-gap-override: 8.916%;
+          font-weight: 400;
+        }
+
+        .foo {
+          font-family: Poppins, "Poppins fallback";
+        }"
+      `)
+  })
+
   it('should ignore unsupported extensions', async () => {
     // @ts-expect-error not typed as mock
     fromFile.mockReset()


### PR DESCRIPTION
resolves https://github.com/unjs/fontaine/issues/258


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for discovering font declarations across nested CSS and SCSS imports.
  - Supports relative, absolute, and package-based imports, including SCSS tilde imports.
  - Ignores conditional, remote, data, and unresolved imports.
  - Correctly handles comments, quoted strings, URLs, and circular imports.
  - Automatically generates deduplicated fallback font faces while preserving existing sources and font metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->