### PR TITLE
fix(fontaine): improve font url resolution

### DIFF
--- a/packages/fontaine/src/css.ts
+++ b/packages/fontaine/src/css.ts
@@ -1,7 +1,9 @@
 import type { Font } from '@capsizecss/unpack'
 import type { CssNode } from 'css-tree'
 import { generate, parse, walk } from 'css-tree'
-import { charIn, createRegExp } from 'magic-regexp'
+import { char, charIn, createRegExp, oneOrMore } from 'magic-regexp'
+import { isAbsolute } from 'pathe'
+import { hasProtocol } from 'ufo'
 
 // See: https://github.com/seek-oss/capsize/blob/master/packages/core/src/round.ts
 function toPercentage(value: number, fractionDigits = 4) {
@@ -21,6 +23,27 @@ const QUOTES_RE = createRegExp(
 )
 
 export const withoutQuotes = (str: string): string => str.trim().replace(QUOTES_RE, '')
+
+const QUERY_OR_FRAGMENT_RE = createRegExp(
+  charIn('?#').and(oneOrMore(char).optionally()).at.lineEnd(),
+)
+
+/** Removes any `?query` or `#fragment` suffix, which is not part of the file a URL points to. */
+export function withoutQueryOrFragment(source: string): string {
+  return source.replace(QUERY_OR_FRAGMENT_RE, '')
+}
+
+/**
+ * Whether a CSS URL may be resolved relative to the stylesheet that declared it, as opposed to
+ * the document root (`/font.woff2`) or an external location (`https:`, `//`, `data:`).
+ *
+ * Bare package specifiers and the webpack `~` convention are indistinguishable from
+ * stylesheet-relative paths here, so callers should fall back to their own resolver when
+ * resolving against the stylesheet finds nothing.
+ */
+export function isStylesheetRelative(source: string): boolean {
+  return !hasProtocol(source, { acceptRelative: true }) && !isAbsolute(source)
+}
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/font-family
 export const genericCSSFamilies: Set<string> = new Set([

--- a/packages/fontaine/src/metrics.ts
+++ b/packages/fontaine/src/metrics.ts
@@ -1,12 +1,13 @@
 import type { Font } from '@capsizecss/unpack'
 import type { FontFaceMetrics } from './css'
 
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { fromUrl } from '@capsizecss/unpack'
 import { fromFile } from '@capsizecss/unpack/fs'
+import { isAbsolute } from 'pathe'
 import { parseURL } from 'ufo'
 
-import { withoutQuotes } from './css'
+import { isStylesheetRelative, withoutQuotes } from './css'
 
 const metricCache: Record<string, FontFaceMetrics | null> = {}
 
@@ -94,6 +95,22 @@ export async function readMetrics(_source: URL | string): Promise<FontFaceMetric
   const filteredMetrics = filterRequiredMetrics(metrics)
   metricCache[source] = filteredMetrics
   return filteredMetrics
+}
+
+/**
+ * Reads font metrics for a `src` URL declared in a stylesheet.
+ *
+ * A scheme-less, non-rooted URL is resolved against the stylesheet first, then handed to
+ * `resolvePath` if that yields no metrics: bare package specifiers and webpack's `~` prefix
+ * look identical to stylesheet-relative paths, and only the caller's resolver can map them.
+ */
+export async function readMetricsForSource(source: string, importer: string | undefined, resolvePath: (path: string) => string | URL): Promise<FontFaceMetrics | null> {
+  if (importer && isAbsolute(importer) && isStylesheetRelative(source)) {
+    const metrics = await readMetrics(new URL(source, pathToFileURL(importer))).catch(() => null)
+    if (metrics)
+      return metrics
+  }
+  return readMetrics(resolvePath(source))
 }
 
 // inline `@capsizecss/metrics`

--- a/packages/fontaine/src/postcss.ts
+++ b/packages/fontaine/src/postcss.ts
@@ -1,14 +1,10 @@
 import type { AtRule, Declaration, Node, Plugin, Result } from 'postcss'
 import type { FontFaceMetrics } from './css'
 import type { FontCategory } from './fallbacks'
-import { pathToFileURL } from 'node:url'
 import { parse } from 'css-tree'
-import { char, charIn, createRegExp, oneOrMore } from 'magic-regexp'
-import { isAbsolute } from 'pathe'
-import { hasProtocol } from 'ufo'
-import { generateFallbackName, generateFontFace, genericCSSFamilies, parseFontFace, withoutQuotes } from './css'
+import { generateFallbackName, generateFontFace, genericCSSFamilies, parseFontFace, withoutQueryOrFragment, withoutQuotes } from './css'
 import { resolveCategoryFallbacks } from './fallbacks'
-import { getMetricsForFamily, readMetrics } from './metrics'
+import { getMetricsForFamily, readMetricsForSource } from './metrics'
 
 export interface FontainePostcssOptions {
   /**
@@ -55,18 +51,6 @@ const supportedExtensions = ['woff2', 'woff', 'ttf']
 // https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_cascade/Value_processing#css-wide_keywords
 const cssWideKeywords = new Set(['inherit', 'initial', 'revert', 'revert-layer', 'unset'])
 
-const QUERY_OR_FRAGMENT_RE = createRegExp(
-  charIn('?#').and(oneOrMore(char).optionally()).at.lineEnd(),
-)
-
-/**
- * Whether a CSS URL is resolved relative to the stylesheet that declared it, as opposed to
- * the document root (`/font.woff2`) or an external location (`https:`, `//`, `data:`).
- */
-function isStylesheetRelative(source: string) {
-  return !hasProtocol(source, { acceptRelative: true }) && !isAbsolute(source)
-}
-
 /**
  * Resolves the file a node originated from, consulting any upstream source map so that
  * relative font URLs are resolved against the stylesheet that actually declared them
@@ -103,13 +87,6 @@ function fontaine(options: FontainePostcssOptions): Plugin {
   const fallbackName = options.fallbackName || generateFallbackName
   const skipFontFaceGeneration = options.skipFontFaceGeneration || (() => false)
 
-  function readMetricsFromId(path: string, importer: string | undefined) {
-    const resolvedPath = importer && isAbsolute(importer) && isStylesheetRelative(path)
-      ? new URL(path, pathToFileURL(importer))
-      : resolvePath(path)
-    return readMetrics(resolvedPath)
-  }
-
   return {
     postcssPlugin: 'fontaine',
     async Once(root, { result, postcss }) {
@@ -120,7 +97,7 @@ function fontaine(options: FontainePostcssOptions): Plugin {
         // `parseFontFace` yields an entry per `src` URL, but a rule declares a single
         // family, so fallbacks are generated from the first source we can read.
         for (const { family, source: url, properties } of parseFontFace(rule.toString())) {
-          const source = url?.replace(QUERY_OR_FRAGMENT_RE, '')
+          const source = url && withoutQueryOrFragment(url)
           if (!supportedExtensions.some(e => source?.endsWith(e)))
             continue
 
@@ -128,7 +105,7 @@ function fontaine(options: FontainePostcssOptions): Plugin {
             continue
 
           const metrics: FontFaceMetrics | null = (await getMetricsForFamily(family))
-            || (source ? await readMetricsFromId(source, originatingFile(rule, result)).catch(() => null) : null)
+            || (source ? await readMetricsForSource(source, originatingFile(rule, result), resolvePath).catch(() => null) : null)
 
           if (!metrics)
             continue

--- a/packages/fontaine/src/transform.ts
+++ b/packages/fontaine/src/transform.ts
@@ -4,15 +4,14 @@ import { readFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { parse, walk } from 'css-tree'
-import { anyOf, char, charIn, createRegExp, exactly, oneOrMore } from 'magic-regexp'
+import { anyOf, char, createRegExp, exactly, oneOrMore } from 'magic-regexp'
 import MagicString from 'magic-string'
 
 import { isAbsolute } from 'pathe'
-import { hasProtocol } from 'ufo'
 import { createUnplugin } from 'unplugin'
-import { generateFallbackName, generateFontFace, parseFontFace, withoutQuotes } from './css'
+import { generateFallbackName, generateFontFace, parseFontFace, withoutQueryOrFragment, withoutQuotes } from './css'
 import { resolveCategoryFallbacks } from './fallbacks'
-import { getMetricsForFamily, readMetrics } from './metrics'
+import { getMetricsForFamily, readMetricsForSource } from './metrics'
 
 export interface FontaineTransformOptions {
   /**
@@ -84,18 +83,6 @@ const CSS_RE = createRegExp(
 const RELATIVE_RE = createRegExp(
   exactly('.').or('..').and(anyOf('/', '\\')).at.lineStart(),
 )
-
-const QUERY_OR_FRAGMENT_RE = createRegExp(
-  charIn('?#').and(oneOrMore(char).optionally()).at.lineEnd(),
-)
-
-/**
- * Whether a CSS URL is resolved relative to the stylesheet that declared it, as opposed to
- * the document root (`/font.woff2`) or an external location (`https:`, `//`, `data:`).
- */
-function isStylesheetRelative(source: string) {
-  return !hasProtocol(source, { acceptRelative: true }) && !isAbsolute(source)
-}
 
 interface CssImport {
   specifier: string
@@ -218,13 +205,6 @@ export const FontaineTransform: ReturnType<typeof createUnplugin<FontaineTransfo
 
   const skipFontFaceGeneration = options.skipFontFaceGeneration || (() => false)
 
-  function readMetricsFromId(path: string, importer: string) {
-    const resolvedPath = isAbsolute(importer) && isStylesheetRelative(path)
-      ? new URL(path, pathToFileURL(importer))
-      : resolvePath(path)
-    return readMetrics(resolvedPath)
-  }
-
   return {
     name: 'fontaine-transform',
     enforce: 'pre',
@@ -268,13 +248,13 @@ export const FontaineTransform: ReturnType<typeof createUnplugin<FontaineTransfo
         }
 
         for (const { family, source: rawSource, index, properties, importer, prefix } of fontFaces) {
-          const source = rawSource?.replace(QUERY_OR_FRAGMENT_RE, '')
+          const source = rawSource && withoutQueryOrFragment(rawSource)
           if (!supportedExtensions.some(e => source?.endsWith(e)))
             continue
           if (skipFontFaceGeneration(fallbackName(family)))
             continue
 
-          const metrics = (await getMetricsForFamily(family)) || (source && (await readMetricsFromId(source, importer).catch(() => null)))
+          const metrics = (await getMetricsForFamily(family)) || (source && (await readMetricsForSource(source, importer, resolvePath).catch(() => null)))
 
           /* v8 ignore next 2 */
           if (!metrics)

--- a/packages/fontaine/src/transform.ts
+++ b/packages/fontaine/src/transform.ts
@@ -4,10 +4,11 @@ import { readFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { parse, walk } from 'css-tree'
-import { anyOf, char, createRegExp, exactly, oneOrMore } from 'magic-regexp'
+import { anyOf, char, charIn, createRegExp, exactly, oneOrMore } from 'magic-regexp'
 import MagicString from 'magic-string'
 
 import { isAbsolute } from 'pathe'
+import { hasProtocol } from 'ufo'
 import { createUnplugin } from 'unplugin'
 import { generateFallbackName, generateFontFace, parseFontFace, withoutQuotes } from './css'
 import { resolveCategoryFallbacks } from './fallbacks'
@@ -83,6 +84,18 @@ const CSS_RE = createRegExp(
 const RELATIVE_RE = createRegExp(
   exactly('.').or('..').and(anyOf('/', '\\')).at.lineStart(),
 )
+
+const QUERY_OR_FRAGMENT_RE = createRegExp(
+  charIn('?#').and(oneOrMore(char).optionally()).at.lineEnd(),
+)
+
+/**
+ * Whether a CSS URL is resolved relative to the stylesheet that declared it, as opposed to
+ * the document root (`/font.woff2`) or an external location (`https:`, `//`, `data:`).
+ */
+function isStylesheetRelative(source: string) {
+  return !hasProtocol(source, { acceptRelative: true }) && !isAbsolute(source)
+}
 
 interface CssImport {
   specifier: string
@@ -206,7 +219,7 @@ export const FontaineTransform: ReturnType<typeof createUnplugin<FontaineTransfo
   const skipFontFaceGeneration = options.skipFontFaceGeneration || (() => false)
 
   function readMetricsFromId(path: string, importer: string) {
-    const resolvedPath = isAbsolute(importer) && RELATIVE_RE.test(path)
+    const resolvedPath = isAbsolute(importer) && isStylesheetRelative(path)
       ? new URL(path, pathToFileURL(importer))
       : resolvePath(path)
     return readMetrics(resolvedPath)
@@ -254,7 +267,8 @@ export const FontaineTransform: ReturnType<typeof createUnplugin<FontaineTransfo
           }
         }
 
-        for (const { family, source, index, properties, importer, prefix } of fontFaces) {
+        for (const { family, source: rawSource, index, properties, importer, prefix } of fontFaces) {
+          const source = rawSource?.replace(QUERY_OR_FRAGMENT_RE, '')
           if (!supportedExtensions.some(e => source?.endsWith(e)))
             continue
           if (skipFontFaceGeneration(fallbackName(family)))

--- a/packages/fontaine/test/postcss.spec.ts
+++ b/packages/fontaine/test/postcss.spec.ts
@@ -187,6 +187,62 @@ describe('fontaine postcss plugin', () => {
     expect(fromFile).toHaveBeenCalledWith(fileURLToPath(new URL('./my.woff2', import.meta.url)))
   })
 
+  it('should resolve bare relative paths against the stylesheet, falling back to `resolvePath`', async () => {
+    // @ts-expect-error not typed as mock
+    fromFile.mockReset()
+
+    const resolvePath = vi.fn((id: string) => id)
+    const from = fileURLToPath(new URL('./test.css', import.meta.url))
+    await process(`
+      @font-face {
+        font-family: "Unknown Family";
+        src: url('fonts/my.woff2') format('woff2');
+      }
+    `, { resolvePath }, from)
+
+    expect(fromFile).toHaveBeenCalledWith(fileURLToPath(new URL('./fonts/my.woff2', import.meta.url)))
+    expect(resolvePath).toHaveBeenCalledWith('fonts/my.woff2')
+  })
+
+  it('should pass bare package specifiers to `resolvePath`', async () => {
+    const from = fileURLToPath(new URL('./test.css', import.meta.url))
+
+    for (const src of ['~@fake-fontsource/dm-sans/files/c.woff2', '@fake-fontsource/dm-sans/files/d.woff2']) {
+      const resolvePath = vi.fn((id: string) => id)
+      await process(`
+        @font-face {
+          font-family: "Unknown Family";
+          src: url('${src}') format('woff2');
+        }
+      `, { resolvePath }, from)
+      expect(resolvePath).toHaveBeenCalledWith(src)
+    }
+  })
+
+  it('should prefer the stylesheet-relative path when it yields metrics', async () => {
+    // @ts-expect-error not typed as mock
+    fromFile.mockResolvedValueOnce({
+      familyName: 'Resolvable Postcss Font',
+      ascent: 1000,
+      descent: 200,
+      lineGap: 0,
+      unitsPerEm: 1000,
+      xWidthAvg: 500,
+    })
+
+    const resolvePath = vi.fn((id: string) => id)
+    const from = fileURLToPath(new URL('./test.css', import.meta.url))
+    await process(`
+      @font-face {
+        font-family: "Resolvable Postcss Font";
+        src: url('fonts/resolvable-postcss.woff2') format('woff2');
+      }
+    `, { resolvePath }, from)
+
+    expect(fromFile).toHaveBeenCalledWith(fileURLToPath(new URL('./fonts/resolvable-postcss.woff2', import.meta.url)))
+    expect(resolvePath).not.toHaveBeenCalled()
+  })
+
   it('should resolve font paths with `resolvePath`', async () => {
     // @ts-expect-error not typed as mock
     fromFile.mockReset()

--- a/packages/fontaine/test/transform.spec.ts
+++ b/packages/fontaine/test/transform.spec.ts
@@ -144,6 +144,49 @@ describe('fontaine transform', () => {
     expect(fromFile).toHaveBeenCalledWith(fileURLToPath(new URL('./my.ttf', import.meta.url)))
   })
 
+  it('should resolve bare relative paths against the stylesheet', async () => {
+    // @ts-expect-error not typed as mock
+    fromFile.mockReset()
+    const cssFilename = fileURLToPath(new URL('./test.css', import.meta.url))
+    await transform(`
+      @font-face {
+        font-family: 'Unique Font';
+        src: url('fonts/my.ttf');
+      }
+    `, {}, cssFilename)
+    expect(fromFile).toHaveBeenCalledWith(fileURLToPath(new URL('./fonts/my.ttf', import.meta.url)))
+  })
+
+  it('should not resolve root-relative, protocol-relative or absolute URLs against the stylesheet', async () => {
+    const cssFilename = fileURLToPath(new URL('./test.css', import.meta.url))
+    const resolvePath = vi.fn((id: string) => id)
+
+    for (const src of ['/fonts/my.ttf', '//example.com/my.ttf', 'https://example.com/my.ttf']) {
+      await transform(`
+        @font-face {
+          font-family: 'Unique Font';
+          src: url('${src}');
+        }
+      `, { resolvePath }, cssFilename)
+      expect(resolvePath).toHaveBeenCalledWith(src)
+    }
+  })
+
+  it('should ignore query strings and fragments in font URLs', async () => {
+    for (const suffix of ['?v=1', '#iefix']) {
+      // @ts-expect-error not typed as mock
+      fromFile.mockReset()
+      const cssFilename = fileURLToPath(new URL('./test.css', import.meta.url))
+      await transform(`
+        @font-face {
+          font-family: 'Unique Font';
+          src: url('./my.ttf${suffix}');
+        }
+      `, {}, cssFilename)
+      expect(fromFile).toHaveBeenCalledWith(fileURLToPath(new URL('./my.ttf', import.meta.url)))
+    }
+  })
+
   it('should generate @font-face rules for fonts pulled in via CSS `@import`', async () => {
     const cssFilename = fileURLToPath(new URL('./test.css', import.meta.url))
     expect(await transform(`

--- a/packages/fontaine/test/transform.spec.ts
+++ b/packages/fontaine/test/transform.spec.ts
@@ -144,17 +144,19 @@ describe('fontaine transform', () => {
     expect(fromFile).toHaveBeenCalledWith(fileURLToPath(new URL('./my.ttf', import.meta.url)))
   })
 
-  it('should resolve bare relative paths against the stylesheet', async () => {
+  it('should resolve bare relative paths against the stylesheet, falling back to `resolvePath`', async () => {
     // @ts-expect-error not typed as mock
     fromFile.mockReset()
+    const resolvePath = vi.fn((id: string) => id)
     const cssFilename = fileURLToPath(new URL('./test.css', import.meta.url))
     await transform(`
       @font-face {
         font-family: 'Unique Font';
         src: url('fonts/my.ttf');
       }
-    `, {}, cssFilename)
+    `, { resolvePath }, cssFilename)
     expect(fromFile).toHaveBeenCalledWith(fileURLToPath(new URL('./fonts/my.ttf', import.meta.url)))
+    expect(resolvePath).toHaveBeenCalledWith('fonts/my.ttf')
   })
 
   it('should not resolve root-relative, protocol-relative or absolute URLs against the stylesheet', async () => {
@@ -185,6 +187,45 @@ describe('fontaine transform', () => {
       `, {}, cssFilename)
       expect(fromFile).toHaveBeenCalledWith(fileURLToPath(new URL('./my.ttf', import.meta.url)))
     }
+  })
+
+  it('should pass bare package specifiers to `resolvePath`', async () => {
+    const cssFilename = fileURLToPath(new URL('./test.css', import.meta.url))
+
+    for (const src of ['~@fake-fontsource/dm-sans/files/a.woff2', '@fake-fontsource/dm-sans/files/b.woff2']) {
+      const resolvePath = vi.fn((id: string) => id)
+      await transform(`
+        @font-face {
+          font-family: 'Unique Font';
+          src: url('${src}');
+        }
+      `, { resolvePath }, cssFilename)
+      expect(resolvePath).toHaveBeenCalledWith(src)
+    }
+  })
+
+  it('should prefer the stylesheet-relative path when it yields metrics', async () => {
+    // @ts-expect-error not typed as mock
+    fromFile.mockResolvedValueOnce({
+      familyName: 'Resolvable Font',
+      ascent: 1000,
+      descent: 200,
+      lineGap: 0,
+      unitsPerEm: 1000,
+      xWidthAvg: 500,
+    })
+
+    const resolvePath = vi.fn((id: string) => id)
+    const cssFilename = fileURLToPath(new URL('./test.css', import.meta.url))
+    await transform(`
+      @font-face {
+        font-family: 'Resolvable Font';
+        src: url('fonts/resolvable.woff2');
+      }
+    `, { resolvePath }, cssFilename)
+
+    expect(fromFile).toHaveBeenCalledWith(fileURLToPath(new URL('./fonts/resolvable.woff2', import.meta.url)))
+    expect(resolvePath).not.toHaveBeenCalled()
   })
 
   it('should generate @font-face rules for fonts pulled in via CSS `@import`', async () => {

--- a/packages/fontaine/vitest.config.ts
+++ b/packages/fontaine/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   test: {
     coverage: {
       thresholds: {
-        branches: 94.8,
+        branches: 94.84,
         functions: 100,
         lines: 100,
         statements: 100,


### PR DESCRIPTION
this includes some fixes to font url resolution including bare relative or query suffixed font urls, as well as stylesheet-relative urls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved font metric loading for stylesheet-relative font paths.
  * Preserved support for absolute, root-relative, protocol-relative, and package-based font sources.
  * Removed query strings and fragments before resolving font metrics.
  * Added fallback handling when stylesheet-relative paths cannot be resolved.

* **Tests**
  * Added coverage for font URL resolution, fallback behavior, and path precedence.
  * Increased branch coverage requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->