### PR TITLE
fix(fontaine): don't add fallbacks to generic families or CSS keywords

### DIFF
--- a/packages/fontaine/src/css.ts
+++ b/packages/fontaine/src/css.ts
@@ -45,6 +45,9 @@ export function isStylesheetRelative(source: string): boolean {
   return !hasProtocol(source, { acceptRelative: true }) && !isAbsolute(source)
 }
 
+// https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_cascade/Value_processing#css-wide_keywords
+export const cssWideKeywords: Set<string> = new Set(['inherit', 'initial', 'revert', 'revert-layer', 'unset'])
+
 // https://developer.mozilla.org/en-US/docs/Web/CSS/font-family
 export const genericCSSFamilies: Set<string> = new Set([
   'serif',

--- a/packages/fontaine/src/postcss.ts
+++ b/packages/fontaine/src/postcss.ts
@@ -2,7 +2,7 @@ import type { AtRule, Declaration, Node, Plugin, Result } from 'postcss'
 import type { FontFaceMetrics } from './css'
 import type { FontCategory } from './fallbacks'
 import { parse } from 'css-tree'
-import { generateFallbackName, generateFontFace, genericCSSFamilies, parseFontFace, withoutQueryOrFragment, withoutQuotes } from './css'
+import { cssWideKeywords, generateFallbackName, generateFontFace, genericCSSFamilies, parseFontFace, withoutQueryOrFragment, withoutQuotes } from './css'
 import { resolveCategoryFallbacks } from './fallbacks'
 import { getMetricsForFamily, readMetricsForSource } from './metrics'
 
@@ -47,9 +47,6 @@ export interface FontainePostcssOptions {
 }
 
 const supportedExtensions = ['woff2', 'woff', 'ttf']
-
-// https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_cascade/Value_processing#css-wide_keywords
-const cssWideKeywords = new Set(['inherit', 'initial', 'revert', 'revert-layer', 'unset'])
 
 /**
  * Resolves the file a node originated from, consulting any upstream source map so that

--- a/packages/fontaine/src/transform.ts
+++ b/packages/fontaine/src/transform.ts
@@ -9,7 +9,7 @@ import MagicString from 'magic-string'
 
 import { isAbsolute } from 'pathe'
 import { createUnplugin } from 'unplugin'
-import { generateFallbackName, generateFontFace, parseFontFace, withoutQueryOrFragment, withoutQuotes } from './css'
+import { cssWideKeywords, generateFallbackName, generateFontFace, genericCSSFamilies, parseFontFace, withoutQueryOrFragment, withoutQuotes } from './css'
 import { resolveCategoryFallbacks } from './fallbacks'
 import { getMetricsForFamily, readMetricsForSource } from './metrics'
 
@@ -306,14 +306,16 @@ export const FontaineTransform: ReturnType<typeof createUnplugin<FontaineTransfo
               if (child.type === 'String') {
                 family = withoutQuotes(child.value)
               }
-              else if (child.type === 'Identifier' && child.name !== 'inherit') {
+              else if (child.type === 'Identifier' && !cssWideKeywords.has(child.name.toLowerCase())) {
                 family = child.name
               }
 
               if (!family)
                 continue
 
-              s.appendRight(child.loc!.end.offset, `, "${fallbackName(family)}"`)
+              if (!genericCSSFamilies.has(family.toLowerCase())) {
+                s.appendRight(child.loc!.end.offset, `, "${fallbackName(family)}"`)
+              }
               return
             }
           },

--- a/packages/fontaine/test/postcss.spec.ts
+++ b/packages/fontaine/test/postcss.spec.ts
@@ -123,6 +123,16 @@ describe('fontaine postcss plugin', () => {
     `)
   })
 
+  it('should not add fallbacks for any generic family or CSS-wide keyword', async () => {
+    for (const value of ['sans-serif', 'monospace', 'system-ui', 'inherit', 'initial', 'unset', 'revert', 'revert-layer']) {
+      expect(await process(`.foo { font-family: ${value}; }`)).toBe(`.foo { font-family: ${value}; }`)
+    }
+  })
+
+  it('should add a fallback for a real family followed by a generic family', async () => {
+    expect(await process('.foo { font-family: Poppins, sans-serif; }')).toBe('.foo { font-family: Poppins, "Poppins fallback", sans-serif; }')
+  })
+
   it('should add fallbacks for families declared in another stylesheet', async () => {
     expect(await process(`
       body {

--- a/packages/fontaine/test/transform.spec.ts
+++ b/packages/fontaine/test/transform.spec.ts
@@ -41,6 +41,17 @@ describe('fontaine transform', () => {
       `)
   })
 
+  it('should not add fallbacks for generic families or CSS-wide keywords', async () => {
+    for (const value of ['sans-serif', 'monospace', 'system-ui', 'inherit', 'initial', 'unset', 'revert', 'revert-layer']) {
+      expect(await transform(`.foo { font-family: ${value}; }`)).toBeUndefined()
+    }
+  })
+
+  it('should add a fallback for a real family followed by a generic family', async () => {
+    expect(await transform('.foo { font-family: Poppins, sans-serif; }'))
+      .toMatchInlineSnapshot(`".foo { font-family: Poppins, "Poppins fallback", sans-serif; }"`)
+  })
+
   it('should add additional @font-face declarations', async () => {
     expect(await transform(`
       @font-face {

--- a/packages/fontaine/vitest.config.ts
+++ b/packages/fontaine/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   test: {
     coverage: {
       thresholds: {
-        branches: 94.84,
+        branches: 94.89,
         functions: 100,
         lines: 100,
         statements: 100,


### PR DESCRIPTION
spotted when reviewing https://github.com/unjs/fontaine/pull/805

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved font-family fallback handling for generic families such as `serif`, `sans-serif`, `monospace`, and `system-ui`.
  * CSS-wide keywords like `inherit`, `initial`, `unset`, `revert`, and `revert-layer` are now handled correctly without adding fallback fonts.
  * Fallback fonts are still inserted appropriately before generic families when a specific font is provided.

* **Tests**
  * Expanded coverage for generic families, CSS-wide keywords, and mixed font-family declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->