### PR TITLE
fix(fontless): detect `--*-font-family` variables by default

### DIFF
--- a/packages/fontless/src/types.ts
+++ b/packages/fontless/src/types.ts
@@ -181,7 +181,7 @@ export interface FontlessOptions {
    * You can enable support for processing CSS variables for font family names.
    *
    * - `false` — disable CSS variable processing
-   * - `'font-prefixed-only'` — process only `--font-*` CSS variables
+   * - `'font-prefixed-only'` — process `--font-*` CSS variables, plus any `--*-font-family` variable (such as Tailwind v4's `--default-font-family`)
    * - `true` — process all CSS variables (may have performance impact)
    * - Any custom string — process only CSS variables matching `--<prefix>*` (e.g., `'my-app'` processes `--my-app-*` variables)
    *

--- a/packages/fontless/src/utils.ts
+++ b/packages/fontless/src/utils.ts
@@ -57,7 +57,7 @@ function shouldSkipDeclaration(
   if (!processCSSVariables)
     return true
   if (processCSSVariables === 'font-prefixed-only')
-    return !property.startsWith('--font')
+    return !property.startsWith('--font') && !(property.startsWith('--') && property.endsWith('-font-family'))
   if (processCSSVariables === true)
     return !property.startsWith('--')
   return !property.startsWith(`--${processCSSVariables}-`)

--- a/packages/fontless/test/parse.spec.ts
+++ b/packages/fontless/test/parse.spec.ts
@@ -307,6 +307,18 @@ describe('custom prefix for processCSSVariables', () => {
     expect(result).not.toContain(`src: url("/otherfont.woff2")`)
   })
 
+  it('should process Tailwind v4 `--default-font-family` with the default setting', async () => {
+    const result = await transformWithPrefix(`@layer theme { :root, :host { --default-font-family: "Rubik Storm", sans-serif; } } @layer base { :root, :host { font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif); } }`, 'font-prefixed-only')
+    expect(result).toContain('@font-face')
+    expect(result).toContain(`src: url("/rubik-storm.woff2")`)
+  })
+
+  it('should process any `-font-family` custom property with the default setting', async () => {
+    const result = await transformWithPrefix(`:root { --default-mono-font-family: 'CustomFont'; --other-var: 'OtherFont' }`, 'font-prefixed-only')
+    expect(result).toContain(`src: url("/customfont.woff2")`)
+    expect(result).not.toContain(`src: url("/otherfont.woff2")`)
+  })
+
   it('should treat empty string prefix as disabled (no CSS variable processing)', async () => {
     const cssVarOnly = await transformWithPrefix(`:root { --heading: 'CustomFont' }`, '')
     expect(cssVarOnly).not.toContain('@font-face')


### PR DESCRIPTION
spotted in https://github.com/nuxt/fonts/issues/772

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved font variable detection when processing CSS variables in font-prefixed-only mode.
  * Tailwind v4’s `--default-font-family` and other `-font-family` variables are now handled correctly, while unrelated variables remain excluded.

* **Tests**
  * Added coverage confirming matching font-face generation and filtering behavior.

* **Documentation**
  * Clarified which font-family variables are processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->