### PR TITLE
fix(fontless): apply family-level `@font-face` descriptors

### DIFF
--- a/packages/fontless/src/resolve.ts
+++ b/packages/fontless/src/resolve.ts
@@ -18,6 +18,37 @@ interface ResolverContext {
   providers: Record<string, (opts: unknown) => Provider>
 }
 
+/** Family-level keys that are not `@font-face` descriptors and must not be passed through to `normalizeFontData`. */
+const NON_DESCRIPTOR_KEYS = new Set(['name', 'global', 'preload', 'fallbacks', 'provider', 'providerOptions'])
+
+function pickDescriptors(override: FontFamilyManualOverride): RawFontFaceData {
+  const face: Record<string, unknown> = {}
+  for (const key in override) {
+    if (!NON_DESCRIPTOR_KEYS.has(key)) {
+      face[key] = override[key as keyof FontFamilyManualOverride]
+    }
+  }
+  return face as unknown as RawFontFaceData
+}
+
+function toArray<T>(value?: T | T[]): T[] | undefined {
+  return value === undefined ? undefined : Array.isArray(value) ? value : [value]
+}
+
+/** Apply family-level `@font-face` descriptors to faces resolved by a provider. */
+function applyFaceOverrides(override: FontFamilyManualOverride | FontFamilyProviderOverride | undefined, fonts: FontFaceData[]): FontFaceData[] {
+  const display = override && 'display' in override ? override.display : undefined
+  const unicodeRange = override && 'unicodeRange' in override ? toArray(override.unicodeRange) : undefined
+  if (!display && !unicodeRange) {
+    return fonts
+  }
+  return fonts.map(font => ({
+    ...font,
+    ...(display && { display }),
+    ...(unicodeRange && { unicodeRange }),
+  }))
+}
+
 export type Resolver = (fontFamily: string, override?: FontFamilyManualOverride | FontFamilyProviderOverride, fallbackOptions?: {
   fallbacks: string[]
   generic?: GenericCSSFamily
@@ -80,12 +111,7 @@ export async function createResolver(context: ResolverContext): Promise<Resolver
     const fallbacks = (override && 'fallbacks' in override ? override.fallbacks : undefined) || normalizedDefaults.fallbacks[fallbackOptions?.generic || 'sans-serif']
 
     if (override && 'src' in override) {
-      const fonts = addFallbacks(fontFamily, normalizeFontData({
-        src: override.src,
-        display: override.display,
-        weight: override.weight,
-        style: override.style,
-      }))
+      const fonts = addFallbacks(fontFamily, normalizeFontData(pickDescriptors(override)))
       exposeFont({
         type: 'manual',
         fontFamily,
@@ -124,7 +150,7 @@ export async function createResolver(context: ResolverContext): Promise<Resolver
           : defaults
         const result = await unifont.resolveFont(fontFamily, resolveOptions as typeof defaults, [override.provider])
         // Rewrite font source URLs to be proxied/local URLs
-        const fonts = normalizeFontData(result.fonts)
+        const fonts = applyFaceOverrides(override, normalizeFontData(result.fonts))
         if (!fonts.length) {
           logger.warn(`Could not produce font face declaration from \`${override.provider}\` for font family \`${fontFamily}\`.`)
           return
@@ -153,7 +179,7 @@ export async function createResolver(context: ResolverContext): Promise<Resolver
 
     const result = await unifont.resolveFont(fontFamily, resolveOptions as typeof defaults, [...prioritisedProviders])
     // Rewrite font source URLs to be proxied/local URLs
-    const fonts = normalizeFontData(result.fonts)
+    const fonts = applyFaceOverrides(override, normalizeFontData(result.fonts))
     if (fonts.length === 0) {
       if (override) {
         logger.warn(`Could not produce font face declaration for \`${fontFamily}\` with override.`)

--- a/packages/fontless/src/resolve.ts
+++ b/packages/fontless/src/resolve.ts
@@ -31,14 +31,15 @@ function pickDescriptors(override: FontFamilyManualOverride): RawFontFaceData {
   return face as unknown as RawFontFaceData
 }
 
-function toArray<T>(value?: T | T[]): T[] | undefined {
-  return value === undefined ? undefined : Array.isArray(value) ? value : [value]
+function toArray<T>(value: T | T[]): T[] {
+  return Array.isArray(value) ? value : [value]
 }
 
 /** Apply family-level `@font-face` descriptors to faces resolved by a provider. */
 function applyFaceOverrides(override: FontFamilyManualOverride | FontFamilyProviderOverride | undefined, fonts: FontFaceData[]): FontFaceData[] {
   const display = override && 'display' in override ? override.display : undefined
-  const unicodeRange = override && 'unicodeRange' in override ? toArray(override.unicodeRange) : undefined
+  const rawUnicodeRange = override && 'unicodeRange' in override ? override.unicodeRange : undefined
+  const unicodeRange = rawUnicodeRange ? toArray(rawUnicodeRange) : undefined
   if (!display && !unicodeRange) {
     return fonts
   }

--- a/packages/fontless/src/types.ts
+++ b/packages/fontless/src/types.ts
@@ -60,6 +60,10 @@ export interface FontFamilyProviderOverride extends FontFamilyOverrides, Partial
    * These options are passed to the provider when resolving this specific font.
    */
   providerOptions?: ProviderFamilyOptions
+  /** `font-display` descriptor to apply to every `@font-face` resolved for this family. */
+  display?: FontFaceData['display']
+  /** `unicode-range` descriptor to apply to every `@font-face` resolved for this family. */
+  unicodeRange?: string | string[]
 }
 
 export type FontSource = string | LocalFontSource | RemoteFontSource

--- a/packages/fontless/test/resolve.spec.ts
+++ b/packages/fontless/test/resolve.spec.ts
@@ -566,7 +566,7 @@ describe('createResolver', () => {
 
   describe('font face descriptors', () => {
     it('should apply display and unicodeRange to faces from an explicit provider', async () => {
-      const { provider } = createTrackingProvider('test')
+      const provider = createEmptyProvider('test', { fonts: [{ display: 'swap', unicodeRange: ['U+0000-007F'], src: [{ url: '/font.woff2' }] }] })
 
       const resolver = await createResolver({
         options: { providers: { test: provider } },
@@ -588,7 +588,7 @@ describe('createResolver', () => {
     })
 
     it('should apply display and unicodeRange to auto-resolved faces', async () => {
-      const { provider } = createTrackingProvider('test')
+      const provider = createEmptyProvider('test', { fonts: [{ display: 'swap', unicodeRange: ['U+0000-007F'], src: [{ url: '/font.woff2' }] }] })
 
       const resolver = await createResolver({
         options: { providers: { test: provider } },
@@ -621,6 +621,40 @@ describe('createResolver', () => {
 
       expect(result?.fonts?.[0]).toMatchObject({ display: 'block' })
       expect(result?.fonts?.[0]).not.toHaveProperty('unicodeRange', expect.anything())
+    })
+
+    it('should apply display without touching a provider unicodeRange', async () => {
+      const provider = createEmptyProvider('test', { fonts: [{ display: 'swap', unicodeRange: ['U+0000-007F'], src: [{ url: '/font.woff2' }] }] })
+
+      const resolver = await createResolver({
+        options: { providers: { test: provider } },
+        providers: { test: provider },
+        normalizeFontData: defaultNormalizeFontData,
+      })
+
+      const result = await resolver('Inter', { name: 'Inter', display: 'optional' })
+
+      expect(result?.fonts?.[0]).toMatchObject({
+        display: 'optional',
+        unicodeRange: ['U+0000-007F'],
+      })
+    })
+
+    it('should apply unicodeRange without touching a provider display', async () => {
+      const provider = createEmptyProvider('test', { fonts: [{ display: 'swap', unicodeRange: ['U+0000-007F'], src: [{ url: '/font.woff2' }] }] })
+
+      const resolver = await createResolver({
+        options: { providers: { test: provider } },
+        providers: { test: provider },
+        normalizeFontData: defaultNormalizeFontData,
+      })
+
+      const result = await resolver('Inter', { name: 'Inter', unicodeRange: 'U+0131' })
+
+      expect(result?.fonts?.[0]).toMatchObject({
+        display: 'swap',
+        unicodeRange: ['U+0131'],
+      })
     })
 
     it('should pass all descriptors through for a manually declared family', async () => {

--- a/packages/fontless/test/resolve.spec.ts
+++ b/packages/fontless/test/resolve.spec.ts
@@ -564,6 +564,106 @@ describe('createResolver', () => {
     })
   })
 
+  describe('font face descriptors', () => {
+    it('should apply display and unicodeRange to faces from an explicit provider', async () => {
+      const { provider } = createTrackingProvider('test')
+
+      const resolver = await createResolver({
+        options: { providers: { test: provider } },
+        providers: { test: provider },
+        normalizeFontData: defaultNormalizeFontData,
+      })
+
+      const result = await resolver('Inter', {
+        name: 'Inter',
+        provider: 'test',
+        display: 'optional',
+        unicodeRange: 'U+0000-00FF',
+      })
+
+      expect(result?.fonts?.[0]).toMatchObject({
+        display: 'optional',
+        unicodeRange: ['U+0000-00FF'],
+      })
+    })
+
+    it('should apply display and unicodeRange to auto-resolved faces', async () => {
+      const { provider } = createTrackingProvider('test')
+
+      const resolver = await createResolver({
+        options: { providers: { test: provider } },
+        providers: { test: provider },
+        normalizeFontData: defaultNormalizeFontData,
+      })
+
+      const result = await resolver('Inter', {
+        name: 'Inter',
+        display: 'optional',
+        unicodeRange: ['U+0000-00FF', 'U+0131'],
+      })
+
+      expect(result?.fonts?.[0]).toMatchObject({
+        display: 'optional',
+        unicodeRange: ['U+0000-00FF', 'U+0131'],
+      })
+    })
+
+    it('should leave resolved faces untouched when no descriptors are set', async () => {
+      const provider = createEmptyProvider('test', { fonts: [{ display: 'block', src: [{ url: '/font.woff2' }] }] })
+
+      const resolver = await createResolver({
+        options: { providers: { test: provider } },
+        providers: { test: provider },
+        normalizeFontData: defaultNormalizeFontData,
+      })
+
+      const result = await resolver('Inter', { name: 'Inter', weights: [400] })
+
+      expect(result?.fonts?.[0]).toMatchObject({ display: 'block' })
+      expect(result?.fonts?.[0]).not.toHaveProperty('unicodeRange', expect.anything())
+    })
+
+    it('should pass all descriptors through for a manually declared family', async () => {
+      const { provider } = createTrackingProvider('test')
+
+      const resolver = await createResolver({
+        options: { providers: { test: provider } },
+        providers: { test: provider },
+        normalizeFontData: defaultNormalizeFontData,
+      })
+
+      const result = await resolver('CustomFont', {
+        name: 'CustomFont',
+        global: true,
+        preload: true,
+        fallbacks: ['Arial'],
+        src: '/custom.woff2',
+        display: 'optional',
+        weight: 700,
+        style: 'italic',
+        unicodeRange: 'U+0000-00FF',
+        stretch: 'condensed',
+        featureSettings: '"liga" 1',
+        variationSettings: '"wght" 700',
+      })
+
+      expect(result?.fonts?.[0]).toMatchObject({
+        display: 'optional',
+        weight: 700,
+        style: 'italic',
+        unicodeRange: ['U+0000-00FF'],
+        stretch: 'condensed',
+        featureSettings: '"liga" 1',
+        variationSettings: '"wght" 700',
+      })
+      expect(result?.fonts?.[0]).not.toHaveProperty('name')
+      expect(result?.fonts?.[0]).not.toHaveProperty('global')
+      expect(result?.fonts?.[0]).not.toHaveProperty('preload')
+      expect(result?.fonts?.[0]).not.toHaveProperty('fallbacks')
+      expect(result?.fallbacks).toEqual(['Arial'])
+    })
+  })
+
   describe('exposeFont', () => {
     it('should report `unknown` when the resolving provider is not named', async () => {
       const provider = createEmptyProvider('test', { fonts: [{ src: [{ url: '/font.woff2' }] }], provider: undefined })


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/fonts/issues/634
resolves https://github.com/nuxt/fonts/issues/180

### 📚 Description

setting a family-level `@font-face` descriptor does nothing:

```ts
fonts: {
  families: [
    { name: 'Inter', provider: 'google', display: 'optional', unicodeRange: 'U+0000-00FF' },
  ],
}
```

you get `font-display: swap` (or `auto` for adobe) and no `unicode-range` at all.

this PR applies `display`/`unicodeRange` to the normalized faces on both provider paths (explicit `provider` and auto-resolution), replaces the four-key pick with a copy of every non-family key so all `RawFontFaceData` descriptors flow through, and adds the two descriptors to `FontFamilyProviderOverride`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for independently overriding `font-display` and `unicode-range` when resolving font families.
  * Unicode ranges can be provided as a single value or an array and are normalized consistently.
  * Manual font definitions support additional `@font-face` descriptors, including weight, style, stretch, feature settings, and variation settings.

* **Bug Fixes**
  * Preserved provider-supplied font-face descriptors when corresponding overrides are not specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->