### PR TITLE
fix(fontless): respect `throwOnError` when an explicit provider resolves nothing

### DIFF
--- a/packages/fontless/src/resolve.ts
+++ b/packages/fontless/src/resolve.ts
@@ -153,7 +153,11 @@ export async function createResolver(context: ResolverContext): Promise<Resolver
         // Rewrite font source URLs to be proxied/local URLs
         const fonts = applyFaceOverrides(override, normalizeFontData(result.fonts))
         if (!fonts.length) {
-          logger.warn(`Could not produce font face declaration from \`${override.provider}\` for font family \`${fontFamily}\`.`)
+          const message = `Could not produce font face declaration from \`${override.provider}\` for font family \`${fontFamily}\`.`
+          if (options.throwOnError) {
+            throw new Error(message)
+          }
+          logger.warn(message)
           return
         }
         const fontsWithLocalFallbacks = addFallbacks(fontFamily, fonts)

--- a/packages/fontless/test/resolve.spec.ts
+++ b/packages/fontless/test/resolve.spec.ts
@@ -548,6 +548,51 @@ describe('createResolver', () => {
       expect(warnings[0]).toContain('Could not produce font face declaration for `Inter` with override')
     })
 
+    it('should throw when an explicit provider produces no font faces and throwOnError is set', async () => {
+      const provider = createEmptyProvider('test', { fonts: [] })
+      const { logger, warnings } = createLogger()
+
+      const resolver = await createResolver({
+        options: { providers: { test: provider }, throwOnError: true },
+        providers: { test: provider },
+        normalizeFontData: defaultNormalizeFontData,
+        logger,
+      })
+
+      await expect(resolver('Inter', { name: 'Inter', provider: 'test' })).rejects.toThrow('Could not produce font face declaration from `test` for font family `Inter`.')
+      expect(warnings).toEqual([])
+    })
+
+    it('should warn when an override produces no font faces even if throwOnError is set', async () => {
+      const provider = createEmptyProvider('test', { fonts: [] })
+      const { logger, warnings } = createLogger()
+
+      const resolver = await createResolver({
+        options: { providers: { test: provider }, throwOnError: true },
+        providers: { test: provider },
+        normalizeFontData: defaultNormalizeFontData,
+        logger,
+      })
+
+      expect(await resolver('Inter', { name: 'Inter', weights: [400] })).toBeUndefined()
+      expect(warnings[0]).toContain('Could not produce font face declaration for `Inter` with override')
+    })
+
+    it('should not throw when no override is present and throwOnError is set', async () => {
+      const provider = createEmptyProvider('test', { fonts: [] })
+      const { logger, warnings } = createLogger()
+
+      const resolver = await createResolver({
+        options: { providers: { test: provider }, throwOnError: true },
+        providers: { test: provider },
+        normalizeFontData: defaultNormalizeFontData,
+        logger,
+      })
+
+      expect(await resolver('Inter')).toBeUndefined()
+      expect(warnings).toEqual([])
+    })
+
     it('should return undefined without warning when no provider resolves the family', async () => {
       const provider = createEmptyProvider('test')
       const { logger, warnings } = createLogger()


### PR DESCRIPTION
this ports https://github.com/nuxt/fonts/pull/518 to `fontless`

resolves https://github.com/nuxt/fonts/issues/356
closes https://github.com/nuxt/fonts/pull/518

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved font resolution error handling when an explicitly selected provider returns no font faces.
  - Configurations that enable error throwing now fail clearly instead of only logging a warning.
  - Other unresolved font scenarios continue to provide appropriate warning behavior.

- **Tests**
  - Added coverage for explicit provider failures, overrides, and unresolved font families.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->