### PR TITLE
fix(fontless): warn if `fontless/runtime` is imported without preloading

### DIFF
--- a/packages/fontless/README.md
+++ b/packages/fontless/README.md
@@ -139,21 +139,24 @@ You can override fallbacks for specific generic families in the `defaults.fallba
 
 ## Preloading Fonts
 
-Preloading is opt-in: no font is preloaded unless you ask for it. Enable it for every resolved font with `defaults.preload`, or for individual families with `families[].preload`:
+Preloading is opt-in: no font is preloaded unless you ask for it. Enable it for every family with `defaults.preload`, or for individual families with `families[].preload`:
 
 ```ts
 fontless({
-  // preload every font fontless resolves
+  // preload the highest-priority font face of every family
   defaults: { preload: true },
-  // ...or only specific families
+  // ...or configure specific families
   families: [
     { name: 'Poppins', preload: true },
-    // `{ subsets: ['latin'] }` and `(family, font) => boolean` are also accepted
+    // preload every face covering a given subset
+    { name: 'Inter', preload: { subsets: ['latin'] } },
+    // or filter faces individually
+    { name: 'Roboto', preload: (family, font) => font.style === 'normal' },
   ],
 })
 ```
 
-For Vite SPA, the selected preload fonts are automatically injected into the HTML.
+For Vite SPA, the selected preload fonts are injected into the HTML, apart from the first `vite dev` render, where the stylesheets have not been transformed yet.
 
 For SSR meta-frameworks which don't rely on [`transformIndexHtml` plugin hook](https://vite.dev/guide/api-plugin.html#transformindexhtml), you need to manually render preload links on the server. Fontless provides `fontless/runtime` module for server to access the necessary data for preload links generation, for example:
 
@@ -227,7 +230,7 @@ function Layout() {
 
 - [SvelteKit](./examples/sveltekit-app)
 
-If `preloads` is an empty array, either no `preload` option is enabled (see above), or `fontless/runtime` was not transformed by the plugin. Check that `fontless()` is in your Vite config and that `fontless/runtime` is not externalised.
+If `preloads` is an empty array, either no `preload` option is enabled, or a configured subset list or filter function matched no font faces, or `fontless/runtime` was not transformed by the plugin. In the last case, check that `fontless()` is in your Vite config and that `fontless/runtime` is not externalised.
 
 ```svelte
 <script lang="ts">

--- a/packages/fontless/README.md
+++ b/packages/fontless/README.md
@@ -139,7 +139,21 @@ You can override fallbacks for specific generic families in the `defaults.fallba
 
 ## Preloading Fonts
 
-Fontless provides an option to select fonts to preload via `preload` option. For Vite SPA, the selected preload fonts are automatically injected into the HTML.
+Preloading is opt-in: no font is preloaded unless you ask for it. Enable it for every resolved font with `defaults.preload`, or for individual families with `families[].preload`:
+
+```ts
+fontless({
+  // preload every font fontless resolves
+  defaults: { preload: true },
+  // ...or only specific families
+  families: [
+    { name: 'Poppins', preload: true },
+    // `{ subsets: ['latin'] }` and `(family, font) => boolean` are also accepted
+  ],
+})
+```
+
+For Vite SPA, the selected preload fonts are automatically injected into the HTML.
 
 For SSR meta-frameworks which don't rely on [`transformIndexHtml` plugin hook](https://vite.dev/guide/api-plugin.html#transformindexhtml), you need to manually render preload links on the server. Fontless provides `fontless/runtime` module for server to access the necessary data for preload links generation, for example:
 
@@ -212,6 +226,8 @@ function Layout() {
 ```
 
 - [SvelteKit](./examples/sveltekit-app)
+
+If `preloads` is an empty array, either no `preload` option is enabled (see above), or `fontless/runtime` was not transformed by the plugin. Check that `fontless()` is in your Vite config and that `fontless/runtime` is not externalised.
 
 ```svelte
 <script lang="ts">

--- a/packages/fontless/src/vite.ts
+++ b/packages/fontless/src/vite.ts
@@ -251,6 +251,7 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
   }
 
   const RUNTIME_PLACEHOLDER = '__FONTLESS_RUNTIME_BUILD_PLACEHOLDER__'
+  let warnedAboutEmptyPreloads = false
   const runtimePlugin: Plugin = {
     name: 'fontless-runtime',
     configEnvironment() {
@@ -287,10 +288,15 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
       order: 'pre',
       handler(code) {
         if (code.includes(RUNTIME_PLACEHOLDER)) {
+          const preloads = getRuntimePreloads()
+          if (preloads.length === 0 && !warnedAboutEmptyPreloads) {
+            warnedAboutEmptyPreloads = true
+            this.warn('`fontless/runtime` was imported but no fonts are marked for preloading, so `preloads` will be empty. Enable `defaults.preload` or set `preload` on individual `families` entries.')
+          }
           const s = new MagicString(code)
           s.replaceAll(
             RUNTIME_PLACEHOLDER,
-            JSON.stringify({ preloads: getRuntimePreloads() }),
+            JSON.stringify({ preloads }),
           )
           return {
             code: s.toString(),

--- a/packages/fontless/test/runtime.spec.ts
+++ b/packages/fontless/test/runtime.spec.ts
@@ -40,32 +40,46 @@ function extractHrefs(chunk: string) {
 const options: FontlessOptions = { families: [{ name: 'Poppins', preload: true }] }
 
 describe('`fontless/runtime` in build', () => {
-  async function buildApp(config: Omit<InlineConfig, 'root' | 'configFile' | 'logLevel'> = {}) {
+  async function buildApp(config: Omit<InlineConfig, 'root' | 'configFile' | 'logLevel'> = {}, fontlessOptions: FontlessOptions = options) {
     const outDir = await fsp.mkdtemp(join(tmpdir(), 'fontless-runtime-'))
     outDirs.push(outDir)
+
+    const warnings: string[] = []
 
     await build({
       ...config,
       root,
       configFile: false,
       logLevel: 'silent',
-      plugins: [entryPlugin(), fontless(options)],
+      plugins: [entryPlugin(), fontless(fontlessOptions)],
       build: {
         ...config.build,
         outDir,
         emptyOutDir: true,
-        rollupOptions: { input: { entry: ENTRY_ID } },
+        rollupOptions: {
+          input: { entry: ENTRY_ID },
+          onwarn: warning => warnings.push(warning.message),
+        },
       },
     })
 
     const files = await Array.fromAsync(fsp.glob('**/*', { cwd: outDir }))
     const chunk = await fsp.readFile(join(outDir, files.find(file => file.endsWith('.js'))!), 'utf-8')
-    return { files, chunk, hrefs: extractHrefs(chunk) }
+    return { files, chunk, warnings, hrefs: extractHrefs(chunk) }
   }
 
-  it('should render preload links pointing at emitted fonts', { timeout: 20_000 }, async () => {
-    const { chunk, files, hrefs } = await buildApp()
+  it('should warn when nothing is configured for preloading', { timeout: 20_000 }, async () => {
+    const { chunk, warnings } = await buildApp({}, { families: [{ name: 'Poppins' }] })
 
+    expect(chunk).not.toContain('__FONTLESS_RUNTIME_BUILD_PLACEHOLDER__')
+    expect(extractHrefs(chunk)).toEqual([])
+    expect(warnings.filter(message => message.includes('no fonts are marked for preloading'))).toHaveLength(1)
+  })
+
+  it('should render preload links pointing at emitted fonts', { timeout: 20_000 }, async () => {
+    const { chunk, files, hrefs, warnings } = await buildApp()
+
+    expect(warnings.filter(message => message.includes('no fonts are marked for preloading'))).toEqual([])
     expect(chunk).not.toContain('__FONTLESS_RUNTIME_BUILD_PLACEHOLDER__')
     expect(chunk).not.toContain('__VITE_ASSET__')
     expect(chunk).toMatch(/rel:["'`]preload/)


### PR DESCRIPTION
resolves https://github.com/unjs/fontaine/issues/811
see https://github.com/theetrain/theetrain-website/pull/19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved font preload handling during runtime builds.
  * Prevented duplicate warnings when no fonts are configured for preloading.
  * Ensured builds without matching preload fonts produce no preload links or unresolved placeholders.

* **Documentation**
  * Clarified that preloading is opt-in.
  * Added guidance for global and per-family settings, subset and filter options, and troubleshooting empty preload results.
  * Documented how selected preload fonts are injected in Vite single-page applications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->