### PR TITLE
feat(fontless): emit `@font-face` for font families registered as `global`

### DIFF
--- a/packages/fontless/README.md
+++ b/packages/fontless/README.md
@@ -306,7 +306,7 @@ function Head() {
 }
 ```
 
-An empty string means no families are configured with `global: true`, or that `fontless/runtime` was not transformed by the plugin.
+An empty string means no families are configured with `global: true`, that none of them resolved to a font, or that `fontless/runtime` was not transformed by the plugin.
 
 ## How It Works
 

--- a/packages/fontless/README.md
+++ b/packages/fontless/README.md
@@ -280,6 +280,34 @@ If `preloads` is an empty array, either no `preload` option is enabled, or a con
 </svelte:head>
 ```
 
+## Global Font Faces
+
+Some fonts are never referenced from CSS that Fontless can see, so there is no usage site to inject their `@font-face` at: a family used only from inline styles, from a canvas, or from a third-party widget. Mark those families `global` and their `@font-face` is emitted regardless of usage.
+
+```ts
+fontless({
+  families: [
+    { name: 'Inter', global: true },
+  ],
+})
+```
+
+For Vite SPA the declarations are inlined into a `<style>` tag in `<head>`, rather than linked as a stylesheet, so the browser learns about the family without waiting for another request. Unlike preloads, this works on the first `vite dev` render, as global families are resolved from your config rather than discovered from stylesheets.
+
+Any usage of the family that *does* appear in CSS still gains the metric-override fallback families, so `global` does not cost you the layout-shift protection.
+
+For SSR meta-frameworks, `fontless/runtime` exposes the same declarations as a string:
+
+```tsx
+import { globalFontFaces } from 'fontless/runtime'
+
+function Head() {
+  return <style dangerouslySetInnerHTML={{ __html: globalFontFaces }} />
+}
+```
+
+An empty string means no families are configured with `global: true`, or that `fontless/runtime` was not transformed by the plugin.
+
 ## How It Works
 
 Fontless works by:

--- a/packages/fontless/docs/content/index.md
+++ b/packages/fontless/docs/content/index.md
@@ -266,6 +266,28 @@ fontless({
 })
 ```
 
+## Global Font Faces
+
+Some fonts are never referenced from CSS that Fontless can see, so there is no usage site to inject their `@font-face` at: a family used only from inline styles, from a canvas, or from a third-party widget. Mark those families `global` and their `@font-face` is emitted regardless of usage.
+
+```js
+fontless({
+  families: [
+    { name: 'Inter', global: true },
+  ],
+})
+```
+
+For Vite SPA the declarations are inlined into a `<style>` tag in `<head>`, rather than linked as a stylesheet, so the browser learns about the family without waiting for another request. Unlike preloads, this works on the first `vite dev` render, as global families are resolved from your config rather than discovered from stylesheets.
+
+Any usage of the family that *does* appear in CSS still gains the metric-override fallback families, so `global` does not cost you the layout-shift protection.
+
+For SSR meta-frameworks, `fontless/runtime` exposes the same declarations as a string:
+
+```ts
+import { globalFontFaces } from 'fontless/runtime'
+```
+
 ## How It Works
 
 `Fontless` works by:

--- a/packages/fontless/src/runtime.ts
+++ b/packages/fontless/src/runtime.ts
@@ -10,7 +10,8 @@ export const preloads: LinkAttributes[] = []
 /**
  * Minified `@font-face` declarations for families configured with `global: true`, which
  * have no usage site in CSS for the plugin to inject them at. Render them in a `<style>`
- * tag in `<head>`; an empty string means no global families are configured.
+ * tag in `<head>`; an empty string means no global families are configured, or that none
+ * of them resolved to a font.
  *
  * The `fontless` Vite plugin replaces this module with the generated CSS, as it does for
  * `preloads`.

--- a/packages/fontless/src/runtime.ts
+++ b/packages/fontless/src/runtime.ts
@@ -7,6 +7,16 @@
  */
 export const preloads: LinkAttributes[] = []
 
+/**
+ * Minified `@font-face` declarations for families configured with `global: true`, which
+ * have no usage site in CSS for the plugin to inject them at. Render them in a `<style>`
+ * tag in `<head>`; an empty string means no global families are configured.
+ *
+ * The `fontless` Vite plugin replaces this module with the generated CSS, as it does for
+ * `preloads`.
+ */
+export const globalFontFaces: string = ''
+
 export interface LinkAttributes {
   rel: 'preload'
   as: 'font'
@@ -16,4 +26,4 @@ export interface LinkAttributes {
 
 // Reaching this module at runtime means the plugin did not replace it, so the import
 // resolved to the published stub and no fonts will be preloaded.
-console.warn('[fontless] `fontless/runtime` was not transformed by the fontless Vite plugin, so no fonts will be preloaded. Check that `fontless()` is in your Vite config and that `fontless/runtime` is not externalised.')
+console.warn('[fontless] `fontless/runtime` was not transformed by the fontless Vite plugin, so no fonts will be preloaded and no global `@font-face` declarations are available. Check that `fontless()` is in your Vite config and that `fontless/runtime` is not externalised.')

--- a/packages/fontless/src/types.ts
+++ b/packages/fontless/src/types.ts
@@ -39,7 +39,11 @@ export type FontProviderName = (string & {}) | 'google' | 'local' | 'none'
 export interface FontFamilyOverrides {
   /** The font family to apply this override to. */
   name: string
-  /** Inject `@font-face` regardless of usage in project. */
+  /**
+   * Inject `@font-face` regardless of usage in the project, into the HTML `<head>` rather
+   * than into any stylesheet. Usage sites found in CSS still gain fallback metric
+   * families. Also available as `globalFontFaces` from `fontless/runtime`.
+   */
   global?: boolean
   preload?: PreloadOption
   /**

--- a/packages/fontless/src/utils.ts
+++ b/packages/fontless/src/utils.ts
@@ -20,14 +20,15 @@ export interface FontFaceResolution {
   fonts?: FontFaceData[]
   fallbacks?: string[]
   /**
-   * Emit only the fallback metric faces, not the primary `@font-face`, and skip
-   * preload registration. For families whose `@font-face` and preload hints are
-   * already emitted elsewhere (such as a global stylesheet) but whose usage sites
-   * should still be rewritten to include metric-override fallbacks.
+   * Emit only the fallback metric faces, not the primary `@font-face`, and register
+   * no preloads (so `selectFontsToPreload` is not called for this family). For
+   * families whose `@font-face` and preload hints are emitted elsewhere, such as a
+   * global stylesheet, but whose usage sites should still be rewritten to include
+   * metric-override fallbacks.
    *
    * `fonts` must still be provided, as fallback metrics are derived from it.
    */
-  skipFontFaceGeneration?: boolean
+  fallbacksOnly?: boolean
 }
 
 export interface FontFamilyInjectionPluginOptions {
@@ -98,7 +99,7 @@ export async function transformCSS(options: FontFamilyInjectionPluginOptions, co
     let insertFontFamilies = false
 
     result.fonts.sort((a, b) => (a.meta?.priority || 0) - (b.meta?.priority || 0))
-    const fontsToPreload = result.skipFontFaceGeneration ? [] : options.selectFontsToPreload?.(fontFamily, result.fonts) ?? []
+    const fontsToPreload = result.fallbacksOnly ? [] : (options.selectFontsToPreload?.(fontFamily, result.fonts) ?? [])
     for (const font of fontsToPreload) {
       const fontToPreload = font.src.find((s): s is RemoteFontSource => 'url' in s)?.url
       if (fontToPreload) {
@@ -115,7 +116,7 @@ export async function transformCSS(options: FontFamilyInjectionPluginOptions, co
 
     for (const font of result.fonts) {
       const fallbackDeclarations = await generateFontFallbacks(fontFamily, font, fallbackMap)
-      const declarations = result.skipFontFaceGeneration
+      const declarations = result.fallbacksOnly
         ? fallbackDeclarations
         : [generateFontFace(fontFamily, opts.relative ? relativiseFontSources(font, withLeadingSlash(dirname(id))) : font), ...fallbackDeclarations]
 

--- a/packages/fontless/src/utils.ts
+++ b/packages/fontless/src/utils.ts
@@ -73,6 +73,30 @@ function shouldSkipDeclaration(
   return !property.startsWith(`--${processCSSVariables}-`)
 }
 
+/**
+ * Minify a generated `@font-face` block for output, or leave it readable in dev. `id` is
+ * the file the declaration will be written into, and is used for diagnostics only.
+ */
+export function renderDeclaration(declaration: string, id: string, options: Pick<FontFamilyInjectionPluginOptions, 'dev' | 'lightningcssOptions'>): string {
+  if (options.dev) {
+    return `${declaration}\n`
+  }
+
+  try {
+    return lightningCSSTransform({
+      filename: id,
+      code: Buffer.from(declaration),
+      minify: true,
+      sourceMap: false,
+      ...options.lightningcssOptions,
+    }).code.toString()
+  }
+  catch (error) {
+    logger.warn(`Could not minify generated \`@font-face\` in \`${id}\`. Falling back to unminified CSS.`, error)
+    return declaration
+  }
+}
+
 export async function transformCSS(options: FontFamilyInjectionPluginOptions, code: string, id: string, opts: { relative?: boolean } = {}): Promise<MagicString> {
   const s = new MagicString(code)
   const ast = parse(code, { positions: true })
@@ -120,28 +144,10 @@ export async function transformCSS(options: FontFamilyInjectionPluginOptions, co
         ? fallbackDeclarations
         : [generateFontFace(fontFamily, opts.relative ? relativiseFontSources(font, withLeadingSlash(dirname(id))) : font), ...fallbackDeclarations]
 
-      for (let declaration of declarations) {
+      for (const declaration of declarations) {
         if (!injectedDeclarations.has(declaration)) {
           injectedDeclarations.add(declaration)
-          if (!options.dev) {
-            try {
-              const result = lightningCSSTransform({
-                filename: id,
-                code: Buffer.from(declaration),
-                minify: true,
-                sourceMap: false,
-                ...options.lightningcssOptions,
-              })
-              declaration = result.code.toString()
-            }
-            catch (error) {
-              logger.warn(`Could not minify generated \`@font-face\` in \`${id}\`. Falling back to unminified CSS.`, error)
-            }
-          }
-          else {
-            declaration += '\n'
-          }
-          prefaces.push(declaration)
+          prefaces.push(renderDeclaration(declaration, id, options))
         }
       }
 

--- a/packages/fontless/src/utils.ts
+++ b/packages/fontless/src/utils.ts
@@ -19,6 +19,15 @@ const logger = consola.withTag('fontless')
 export interface FontFaceResolution {
   fonts?: FontFaceData[]
   fallbacks?: string[]
+  /**
+   * Emit only the fallback metric faces, not the primary `@font-face`, and skip
+   * preload registration. For families whose `@font-face` and preload hints are
+   * already emitted elsewhere (such as a global stylesheet) but whose usage sites
+   * should still be rewritten to include metric-override fallbacks.
+   *
+   * `fonts` must still be provided, as fallback metrics are derived from it.
+   */
+  skipFontFaceGeneration?: boolean
 }
 
 export interface FontFamilyInjectionPluginOptions {
@@ -89,7 +98,7 @@ export async function transformCSS(options: FontFamilyInjectionPluginOptions, co
     let insertFontFamilies = false
 
     result.fonts.sort((a, b) => (a.meta?.priority || 0) - (b.meta?.priority || 0))
-    const fontsToPreload = options.selectFontsToPreload?.(fontFamily, result.fonts) ?? []
+    const fontsToPreload = result.skipFontFaceGeneration ? [] : options.selectFontsToPreload?.(fontFamily, result.fonts) ?? []
     for (const font of fontsToPreload) {
       const fontToPreload = font.src.find((s): s is RemoteFontSource => 'url' in s)?.url
       if (fontToPreload) {
@@ -106,7 +115,9 @@ export async function transformCSS(options: FontFamilyInjectionPluginOptions, co
 
     for (const font of result.fonts) {
       const fallbackDeclarations = await generateFontFallbacks(fontFamily, font, fallbackMap)
-      const declarations = [generateFontFace(fontFamily, opts.relative ? relativiseFontSources(font, withLeadingSlash(dirname(id))) : font), ...fallbackDeclarations]
+      const declarations = result.skipFontFaceGeneration
+        ? fallbackDeclarations
+        : [generateFontFace(fontFamily, opts.relative ? relativiseFontSources(font, withLeadingSlash(dirname(id))) : font), ...fallbackDeclarations]
 
       for (let declaration of declarations) {
         if (!injectedDeclarations.has(declaration)) {

--- a/packages/fontless/src/vite.ts
+++ b/packages/fontless/src/vite.ts
@@ -1,5 +1,5 @@
 import type { RemoteFontSource } from 'unifont'
-import type { Plugin, ViteDevServer } from 'vite'
+import type { Plugin, Rollup, ViteDevServer } from 'vite'
 import type { NormalizeFontDataContext, RenderedFont } from './assets'
 import type { LinkAttributes } from './runtime'
 import type { FontlessOptions } from './types'
@@ -53,12 +53,24 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
 
   // Output file names of emitted fonts, mapped back to their key in `renderedFontURLs`
   const fontFiles = new Map<string, string>()
-  const emittedFonts = new Set<string>()
   function fontFileName(file: string) {
     const fileName = joinURL(assetContext.assetsBaseURL, file).slice(1)
     fontFiles.set(fileName, file)
-    emittedFonts.add(file)
     return fileName
+  }
+
+  // Asset reference ids of emitted fonts, keyed by environment: a font emitted for one
+  // environment cannot be referenced from another, and emitting the same file name twice
+  // within one environment is an error.
+  const fontRefs = new Map<string, string>()
+  function emitFont(ctx: Rollup.PluginContext, file: string, source: Uint8Array | Buffer) {
+    const key = `${ctx.environment.name}:${file}`
+    let ref = fontRefs.get(key)
+    if (!ref) {
+      ref = ctx.emitFile({ type: 'asset', fileName: fontFileName(file), source })!
+      fontRefs.set(key, ref)
+    }
+    return `__VITE_ASSET__${ref}__`
   }
 
   async function loadFont(file: string, { url, init, subset }: RenderedFont): Promise<Buffer> {
@@ -90,6 +102,10 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
   // placeholder, which cannot be rendered into a server bundle: the placeholder's
   // reference id belongs to whichever environment emitted the font.
   const publicFontURLs = new Map<string, string>()
+
+  function publicFontURL(file: string) {
+    return joinURL(assetContext.baseURL, assetContext.assetsBaseURL, file)
+  }
 
   function getPreloadHrefs() {
     return [...cssTransformOptions.fontsToPreload.values()].flatMap(v => [...v])
@@ -145,6 +161,31 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
     })()
 
     return globalFontFaces
+  }
+
+  // Public URL of each global font, mapped to the asset placeholder standing in for it in
+  // the HTML. Empty outside a client build, where there is no HTML to write.
+  let globalAssetURLs: Array<[string, string]> = []
+
+  /**
+   * Emit the fonts referenced only by global `@font-face` declarations, and record the
+   * placeholder standing in for each one, so that `base`, a relative base and
+   * `experimental.renderBuiltUrl` are applied to the URLs written into the HTML.
+   *
+   * Global fonts are not reachable from any module, so they are resolved without a plugin
+   * context and only gain a reference id here.
+   */
+  async function emitGlobalFonts(ctx: Rollup.PluginContext) {
+    await getGlobalFontFaces()
+
+    return Promise.all([...globalFontFiles].map(async (file): Promise<[string, string]> => {
+      const font = assetContext.renderedFontURLs.get(file)!
+      return [publicFontURL(file), emitFont(ctx, file, await loadFont(file, font))]
+    }))
+  }
+
+  function withEmittedAssets(value: string) {
+    return globalAssetURLs.reduce((value, [from, to]) => value.replaceAll(from, to), value)
   }
 
   function toPreloadLinks(hrefs: string[]): LinkAttributes[] {
@@ -249,6 +290,13 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
         cssTransformOptions.lightningcssOptions = config.css.lightningcss as FontFamilyInjectionPluginOptions['lightningcssOptions']
       }
     },
+    async buildStart() {
+      // Only the client build writes HTML, and the placeholders are reference ids scoped to
+      // the environment that emitted them
+      if (command === 'build' && this.environment.config.consumer === 'client') {
+        globalAssetURLs = await emitGlobalFonts(this)
+      }
+    },
     configureServer(server_) {
       // serve font assets via middleware during dev
       // based on https://github.com/nuxt/fonts/blob/e7f537a0357896d34be9c17031b3178fb4e79042/src/assets.ts#L30
@@ -305,20 +353,9 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
       },
     },
     async generateBundle(_options, bundle) {
-      // Resolve first: global fonts are not reachable from any module, so this is the only
-      // thing that populates `globalFontFiles`
-      await getGlobalFontFaces()
-      await Promise.all([...globalFontFiles].map(async (file) => {
-        const font = assetContext.renderedFontURLs.get(file)
-        if (!font || emittedFonts.has(file)) {
-          return
-        }
-        this.emitFile({
-          type: 'asset',
-          fileName: fontFileName(file),
-          source: await loadFont(file, font),
-        })
-      }))
+      // Global fonts are reachable from no module, so nothing else will have emitted them
+      // for this environment
+      await emitGlobalFonts(this)
 
       await Promise.all(Object.values(bundle).map(async (output) => {
         if (output.type !== 'asset') {
@@ -336,12 +373,13 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
         // Inline rather than linking a stylesheet: a blocking request would delay the
         // point at which the browser knows the family exists, which is the only reason
         // these declarations are hoisted out of CSS in the first place.
-        const css = await getGlobalFontFaces()
-
+        //
         // Preload doesn't work on initial rendering during dev since `fontsToPreload`
         // is empty before css is transformed. Global fonts are unaffected, as they are
-        // resolved above rather than discovered.
-        const tags = toPreloadLinks(getPreloadHrefs()).map(attrs => ({
+        // resolved here rather than discovered.
+        const css = withEmittedAssets(await getGlobalFontFaces())
+
+        const tags = toPreloadLinks(getPreloadHrefs().map(withEmittedAssets)).map(attrs => ({
           tag: 'link',
           attrs: attrs as unknown as Record<string, string>,
         }))

--- a/packages/fontless/src/vite.ts
+++ b/packages/fontless/src/vite.ts
@@ -1,3 +1,4 @@
+import type { RemoteFontSource } from 'unifont'
 import type { Plugin, ViteDevServer } from 'vite'
 import type { NormalizeFontDataContext, RenderedFont } from './assets'
 import type { LinkAttributes } from './runtime'
@@ -14,18 +15,23 @@ import MagicString from 'magic-string'
 import { join } from 'pathe'
 import { hasProtocol, joinURL } from 'ufo'
 import { normalizeFontData } from './assets'
+import { generateFontFace } from './css/render'
 import { defaultOptions } from './defaults'
 import { resolveProviders } from './providers'
 import { createResolver } from './resolve'
 import { createFontlessStorage } from './storage'
 import { subsetFontData } from './subset'
-import { transformCSS } from './utils'
+import { renderDeclaration, transformCSS } from './utils'
 
 // Copied from @tailwindcss-vite
 const CSS_LANG_QUERY_RE = /&lang\.css/
 const INLINE_STYLE_ID_RE = /[?&]index=\d+\.css$/
 // Copied from vue-bundle-renderer utils
 const EMPTY_SOURCE = new Uint8Array()
+
+// Fonts declared `global` have no stylesheet of their own, so their declarations are
+// keyed by this synthetic id in `fontsToPreload` and in minification diagnostics.
+const GLOBAL_CSS_ID = '\0fontless:global.css'
 
 const CSS_EXTENSIONS_RE = /\.(?:css|scss|sass|postcss|pcss|less|stylus|styl)(?:\?[^.]+)?$/
 
@@ -40,14 +46,18 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
   let storage: ReturnType<typeof createFontlessStorage>
 
   // `emit` is only available while a CSS module is being transformed, as it needs that
-  // transform's plugin context to emit into the right environment's bundle.
-  const buildContext = new AsyncLocalStorage<{ emit: (file: string) => string }>()
+  // transform's plugin context to emit into the right environment's bundle. `collect`
+  // gathers the fonts referenced by declarations generated outside any CSS module, which
+  // therefore have to be emitted from `generateBundle` instead.
+  const buildContext = new AsyncLocalStorage<{ emit?: (file: string) => string, collect?: Set<string> }>()
 
   // Output file names of emitted fonts, mapped back to their key in `renderedFontURLs`
   const fontFiles = new Map<string, string>()
+  const emittedFonts = new Set<string>()
   function fontFileName(file: string) {
     const fileName = joinURL(assetContext.assetsBaseURL, file).slice(1)
     fontFiles.set(fileName, file)
+    emittedFonts.add(file)
     return fileName
   }
 
@@ -85,6 +95,58 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
     return [...cssTransformOptions.fontsToPreload.values()].flatMap(v => [...v])
   }
 
+  // Fonts referenced only by the global stylesheet, which is not attached to any module
+  const globalFontFiles = new Set<string>()
+  let resolveFontFaceWithOverride: Awaited<ReturnType<typeof createResolver>>
+  let globalFontFaces: Promise<string> | undefined
+
+  /**
+   * Render the `@font-face` blocks for families declared `global`, which by definition
+   * have no usage site in CSS to discover them from, and register their preloads.
+   *
+   * Fallback metric faces are not included: they are emitted per stylesheet alongside the
+   * usage sites they apply to, via `fallbacksOnly`.
+   */
+  function getGlobalFontFaces(): Promise<string> {
+    globalFontFaces ??= (async () => {
+      const families = options.families?.filter(f => f.global) ?? []
+      const declarations: string[] = []
+      const hrefs = new Set<string>()
+
+      for (const family of families) {
+        const result = await buildContext.run(
+          { collect: globalFontFiles },
+          () => resolveFontFaceWithOverride(family.name, family),
+        )
+        if (!result?.fonts?.length) {
+          continue
+        }
+
+        const fonts = [...result.fonts].sort((a, b) => (a.meta?.priority || 0) - (b.meta?.priority || 0))
+        for (const font of cssTransformOptions.selectFontsToPreload?.(family.name, fonts) ?? []) {
+          const url = font.src.find((s): s is RemoteFontSource => 'url' in s)?.url
+          if (url) {
+            hrefs.add(url)
+          }
+        }
+
+        // reverse order by priority since last rule with overlapping unicode-range wins
+        // https://www.w3.org/TR/css-fonts-4/#composite-fonts
+        for (const font of fonts.reverse()) {
+          declarations.push(renderDeclaration(generateFontFace(family.name, font), GLOBAL_CSS_ID, cssTransformOptions))
+        }
+      }
+
+      if (hrefs.size > 0) {
+        cssTransformOptions.fontsToPreload.set(GLOBAL_CSS_ID, hrefs)
+      }
+
+      return declarations.join('')
+    })()
+
+    return globalFontFaces
+  }
+
   function toPreloadLinks(hrefs: string[]): LinkAttributes[] {
     return hrefs.map(href => ({
       rel: 'preload',
@@ -114,10 +176,11 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
         // During build, hand fonts to Vite's asset pipeline rather than writing literal
         // URLs, so `base`, a relative base and `experimental.renderBuiltUrl` all apply.
         resolveAssetURL: config.command === 'build'
-          ? file => buildContext.getStore()?.emit(file)
+          ? file => buildContext.getStore()?.emit?.(file)
           : undefined,
         callback: (file, url) => {
           publicFontURLs.set(url, joinURL(assetContext.baseURL, assetContext.assetsBaseURL, file))
+          buildContext.getStore()?.collect?.add(file)
         },
       }
 
@@ -143,7 +206,7 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
         root: config.root,
       })
 
-      const resolveFontFaceWithOverride = await createResolver({
+      resolveFontFaceWithOverride = await createResolver({
         options,
         providers,
         storage,
@@ -170,13 +233,15 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
         dev: config.mode === 'development',
         async resolveFontFace(fontFamily, fallbackOptions) {
           const override = options.families?.find(f => f.name === fontFamily)
+          const result = await resolveFontFaceWithOverride(fontFamily, override, fallbackOptions)
 
-          // This CSS will be injected in a separate location
-          if (override?.global) {
-            return
+          // The primary `@font-face` is emitted once into the global stylesheet, but usage
+          // sites in this file still need their fallback metric faces
+          if (result && override?.global) {
+            return { ...result, fallbacksOnly: true }
           }
 
-          return resolveFontFaceWithOverride(fontFamily, override, fallbackOptions)
+          return result
         },
       }
 
@@ -240,6 +305,21 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
       },
     },
     async generateBundle(_options, bundle) {
+      // Resolve first: global fonts are not reachable from any module, so this is the only
+      // thing that populates `globalFontFiles`
+      await getGlobalFontFaces()
+      await Promise.all([...globalFontFiles].map(async (file) => {
+        const font = assetContext.renderedFontURLs.get(file)
+        if (!font || emittedFonts.has(file)) {
+          return
+        }
+        this.emitFile({
+          type: 'asset',
+          fileName: fontFileName(file),
+          source: await loadFont(file, font),
+        })
+      }))
+
       await Promise.all(Object.values(bundle).map(async (output) => {
         if (output.type !== 'asset') {
           return
@@ -252,19 +332,38 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
       }))
     },
     transformIndexHtml: {
-      handler() {
+      async handler() {
+        // Inline rather than linking a stylesheet: a blocking request would delay the
+        // point at which the browser knows the family exists, which is the only reason
+        // these declarations are hoisted out of CSS in the first place.
+        const css = await getGlobalFontFaces()
+
         // Preload doesn't work on initial rendering during dev since `fontsToPreload`
-        // is empty before css is transformed.
-        return toPreloadLinks(getPreloadHrefs()).map(attrs => ({
+        // is empty before css is transformed. Global fonts are unaffected, as they are
+        // resolved above rather than discovered.
+        const tags = toPreloadLinks(getPreloadHrefs()).map(attrs => ({
           tag: 'link',
           attrs: attrs as unknown as Record<string, string>,
         }))
+
+        if (css) {
+          tags.push({ tag: 'style', attrs: { type: 'text/css' }, children: css } as never)
+        }
+
+        return tags
       },
     },
   }
 
   function getRuntimePreloads(): LinkAttributes[] {
     return toPreloadLinks(getPreloadHrefs().map(href => publicFontURLs.get(href) ?? href))
+  }
+
+  async function getRuntimeExports() {
+    // `@font-face` blocks must be resolved before preloads are read, as global families
+    // register their preloads as a side effect
+    const globalFontFaces = await getGlobalFontFaces()
+    return { preloads: getRuntimePreloads(), globalFontFaces }
   }
 
   const RUNTIME_PLACEHOLDER = '__FONTLESS_RUNTIME_BUILD_PLACEHOLDER__'
@@ -275,7 +374,7 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
       return {
         resolve: {
           // an externalised import would bypass `resolveId` below and load the
-          // published stub, which has no preloads in it
+          // published stub, which has no preloads or font faces in it
           noExternal: [RUNTIME_NAME],
         },
       }
@@ -290,31 +389,29 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
       },
     },
     load: {
-      handler(id) {
+      async handler(id) {
         if (id === `\0${RUNTIME_NAME}`) {
           // during build, postpone replacement until `renderChunk`
           // to ensure fonts are collected through css transform
           if (command === 'build') {
-            return `export const { preloads } = ${RUNTIME_PLACEHOLDER}`
+            return `export const { preloads, globalFontFaces } = ${RUNTIME_PLACEHOLDER}`
           }
-          return `export const { preloads } = ${JSON.stringify({ preloads: getRuntimePreloads() })}`
+          return `export const { preloads, globalFontFaces } = ${JSON.stringify(await getRuntimeExports())}`
         }
       },
     },
     renderChunk: {
       order: 'pre',
-      handler(code) {
+      async handler(code) {
         if (code.includes(RUNTIME_PLACEHOLDER)) {
-          const preloads = getRuntimePreloads()
+          const exports = await getRuntimeExports()
+          const { preloads } = exports
           if (preloads.length === 0 && !warnedAboutEmptyPreloads) {
             warnedAboutEmptyPreloads = true
             this.warn('`fontless/runtime` was imported but no fonts are marked for preloading, so `preloads` will be empty. Enable `defaults.preload` or set `preload` on individual `families` entries.')
           }
           const s = new MagicString(code)
-          s.replaceAll(
-            RUNTIME_PLACEHOLDER,
-            JSON.stringify({ preloads }),
-          )
+          s.replaceAll(RUNTIME_PLACEHOLDER, JSON.stringify(exports))
           return {
             code: s.toString(),
             map: s.generateMap({ hires: 'boundary' }),

--- a/packages/fontless/src/vite.ts
+++ b/packages/fontless/src/vite.ts
@@ -1,4 +1,4 @@
-import type { RemoteFontSource } from 'unifont'
+import type { FontFaceData, RemoteFontSource } from 'unifont'
 import type { Plugin, Rollup, ViteDevServer } from 'vite'
 import type { NormalizeFontDataContext, RenderedFont } from './assets'
 import type { LinkAttributes } from './runtime'
@@ -107,6 +107,21 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
     return joinURL(assetContext.baseURL, assetContext.assetsBaseURL, file)
   }
 
+  function selectFontsToPreload(fontFamily: string, fonts: FontFaceData[]): FontFaceData[] {
+    const override = options.families?.find(f => f.name === fontFamily)
+    const preload = override?.preload ?? options.defaults?.preload
+    if (preload === true) {
+      return [...fonts].sort((a, b) => (a.meta?.priority || 0) - (b.meta?.priority || 0)).slice(0, 1)
+    }
+    if (typeof preload === 'function') {
+      return fonts.filter(f => preload(fontFamily, f))
+    }
+    if (preload && 'subsets' in preload) {
+      return fonts.filter(f => f.meta?.subset && preload.subsets.includes(f.meta.subset))
+    }
+    return []
+  }
+
   function getPreloadHrefs() {
     return [...cssTransformOptions.fontsToPreload.values()].flatMap(v => [...v])
   }
@@ -139,7 +154,7 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
         }
 
         const fonts = [...result.fonts].sort((a, b) => (a.meta?.priority || 0) - (b.meta?.priority || 0))
-        for (const font of cssTransformOptions.selectFontsToPreload?.(family.name, fonts) ?? []) {
+        for (const font of selectFontsToPreload(family.name, fonts)) {
           const url = font.src.find((s): s is RemoteFontSource => 'url' in s)?.url
           if (url) {
             hrefs.add(url)
@@ -256,20 +271,7 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
 
       cssTransformOptions = {
         processCSSVariables: options.processCSSVariables,
-        selectFontsToPreload(fontFamily, fonts) {
-          const override = options.families?.find(f => f.name === fontFamily)
-          const preload = override?.preload ?? options.defaults?.preload
-          if (preload === true) {
-            return [...fonts].sort((a, b) => (a.meta?.priority || 0) - (b.meta?.priority || 0)).slice(0, 1)
-          }
-          if (typeof preload === 'function') {
-            return fonts.filter(f => preload(fontFamily, f))
-          }
-          if (preload && 'subsets' in preload) {
-            return fonts.filter(f => f.meta?.subset && preload.subsets.includes(f.meta.subset))
-          }
-          return []
-        },
+        selectFontsToPreload,
         fontsToPreload: new Map(),
         dev: config.mode === 'development',
         async resolveFontFace(fontFamily, fallbackOptions) {

--- a/packages/fontless/test/base.spec.ts
+++ b/packages/fontless/test/base.spec.ts
@@ -90,6 +90,39 @@ it('should apply experimental.renderBuiltUrl to font URLs', { timeout: 20_000 },
   expect(html).toContain('href="https://cdn.example.com/assets/_fonts')
 })
 
+it('should apply experimental.renderBuiltUrl to global font URLs', { timeout: 20_000 }, async () => {
+  const { html } = await buildApp({
+    experimental: {
+      renderBuiltUrl(filename, { hostType }) {
+        return filename.includes('_fonts') ? `https://cdn.example.com/${filename}` : { relative: hostType !== 'html' }
+      },
+    },
+  }, { families: [{ name: 'Poppins', global: true, preload: true }] })
+
+  expect(html).toContain('url(https://cdn.example.com/assets/_fonts')
+  expect(html).not.toContain('url(/assets/_fonts')
+  expect(html).toContain('href="https://cdn.example.com/assets/_fonts')
+})
+
+it.each(['./', ''])('should emit global font URLs relative to the HTML for base %s', { timeout: 20_000 }, async (base) => {
+  const { outDir, html, fonts } = await buildApp({ base }, { families: [{ name: 'Poppins', global: true }] })
+
+  const urls = [...html.matchAll(/url\((\.[^)]+\.woff2)\)/g)].map(([, url]) => url!)
+  expect(urls.length).toBeGreaterThan(0)
+
+  for (const url of urls) {
+    expect(fonts).toContain(join('assets/_fonts', url.split('/_fonts/')[1]!))
+    expect((await fsp.stat(join(outDir, url))).size).toBeGreaterThan(0)
+  }
+})
+
+it('should prefix global font URLs with the configured base', { timeout: 20_000 }, async () => {
+  const { html, fonts } = await buildApp({ base: '/build/' }, { families: [{ name: 'Poppins', global: true }] })
+
+  expect(html).toContain('url(/build/assets/_fonts')
+  expect(fonts.some(file => file.endsWith('.woff2'))).toBe(true)
+})
+
 it('should honour renderBuiltUrl returning a relative URL for fonts', { timeout: 20_000 }, async () => {
   const { outDir, css, fonts } = await buildApp({
     experimental: { renderBuiltUrl: () => ({ relative: true }) },

--- a/packages/fontless/test/runtime.spec.ts
+++ b/packages/fontless/test/runtime.spec.ts
@@ -2,7 +2,7 @@ import type { InlineConfig, Plugin } from 'vite'
 import type { FontlessOptions } from '../src/types'
 import { promises as fsp } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { join } from 'pathe'
 import { build, createServer } from 'vite'
 import { afterAll, describe, expect, it, vi } from 'vitest'
@@ -17,7 +17,7 @@ afterAll(async () => {
 
 const ENTRY_ID = 'virtual:fontless-runtime-fixture'
 
-function entryPlugin(): Plugin {
+function entryPlugin({ css = true }: { css?: boolean } = {}): Plugin {
   return {
     name: 'test-runtime-entry',
     resolveId(source) {
@@ -27,7 +27,11 @@ function entryPlugin(): Plugin {
     },
     load(id) {
       if (id === `\0${ENTRY_ID}`) {
-        return `import './src/style.css'\nimport { preloads } from 'fontless/runtime'\nexport { preloads }`
+        return [
+          css ? `import './src/style.css'` : '',
+          `import { preloads, globalFontFaces } from 'fontless/runtime'`,
+          `export { preloads, globalFontFaces }`,
+        ].filter(Boolean).join('\n')
       }
     },
   }
@@ -140,12 +144,61 @@ describe('`fontless/runtime` in dev', () => {
   })
 })
 
+describe('`fontless/runtime` global font faces', () => {
+  const globalOptions: FontlessOptions = {
+    families: [{ name: 'Black Fox', global: true, src: pathToFileURL(join(root, 'src/black-fox.ttf')).href }],
+  }
+
+  it('should expose `@font-face` declarations for `global` families in build', { timeout: 20_000 }, async () => {
+    const outDir = await fsp.mkdtemp(join(tmpdir(), 'fontless-runtime-'))
+    outDirs.push(outDir)
+
+    await build({
+      root,
+      configFile: false,
+      logLevel: 'silent',
+      plugins: [entryPlugin({ css: false }), fontless(globalOptions)],
+      build: { outDir, emptyOutDir: true, rollupOptions: { input: { entry: ENTRY_ID } } },
+    })
+
+    const files = await Array.fromAsync(fsp.glob('**/*', { cwd: outDir }))
+    const chunk = await fsp.readFile(join(outDir, files.find(file => file.endsWith('.js'))!), 'utf-8')
+
+    expect(chunk).not.toContain('__FONTLESS_RUNTIME_BUILD_PLACEHOLDER__')
+    expect(chunk).not.toContain('__VITE_ASSET__')
+    expect(chunk).toContain('@font-face')
+
+    const [, href] = chunk.match(/url\((\/assets\/_fonts\/[^)]+)\)/) ?? []
+    expect(href).toBeDefined()
+    expect(files).toContain(href!.slice(1))
+  })
+
+  it('should expose `@font-face` declarations for `global` families in dev', { timeout: 20_000 }, async () => {
+    const server = await createServer({
+      root,
+      configFile: false,
+      logLevel: 'silent',
+      server: { middlewareMode: true },
+      plugins: [entryPlugin({ css: false }), fontless(globalOptions)],
+    })
+
+    try {
+      const { globalFontFaces } = await server.ssrLoadModule('fontless/runtime')
+      expect(globalFontFaces).toContain(`font-family: 'Black Fox'`)
+    }
+    finally {
+      await server.close()
+    }
+  })
+})
+
 describe('published `fontless/runtime` stub', () => {
   it('should warn that no fonts will be preloaded', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     try {
-      const { preloads } = await import('../src/runtime')
+      const { preloads, globalFontFaces } = await import('../src/runtime')
       expect(preloads).toEqual([])
+      expect(globalFontFaces).toBe('')
       expect(warn).toHaveBeenCalledWith(expect.stringContaining('was not transformed by the fontless Vite plugin'))
     }
     finally {

--- a/packages/fontless/test/utils.spec.ts
+++ b/packages/fontless/test/utils.spec.ts
@@ -46,6 +46,48 @@ describe('transformCSS', () => {
     expect(fontsToPreload.size).toBe(0)
   })
 
+  it('should emit fallbacks without the primary `@font-face` when `skipFontFaceGeneration` is set', async () => {
+    const result = await transform(`:root { font-family: 'Poppins' }`, {
+      resolveFontFace: () => ({
+        fonts: [{ src: [{ url: '/poppins.woff2', format: 'woff2' }] }],
+        fallbacks: ['Arial'],
+        skipFontFaceGeneration: true,
+      }),
+    })
+
+    expect(result).toContain(`font-family: "Poppins Fallback: Arial"`)
+    expect(result).toContain(`font-family: 'Poppins', "Poppins Fallback: Arial"`)
+    expect(result).not.toContain(`font-family: 'Poppins';`)
+  })
+
+  it('should emit the primary `@font-face` alongside fallbacks by default', async () => {
+    const result = await transform(`:root { font-family: 'Poppins' }`, {
+      resolveFontFace: () => ({
+        fonts: [{ src: [{ url: '/poppins.woff2', format: 'woff2' }] }],
+        fallbacks: ['Arial'],
+      }),
+    })
+
+    expect(result).toContain(`font-family: 'Poppins';`)
+    expect(result).toContain(`font-family: "Poppins Fallback: Arial"`)
+    expect(result).toContain(`font-family: 'Poppins', "Poppins Fallback: Arial"`)
+  })
+
+  it('should not register preloads when `skipFontFaceGeneration` is set', async () => {
+    const fontsToPreload = new Map<string, Set<string>>()
+    await transform(`:root { font-family: 'Poppins' }`, {
+      fontsToPreload,
+      selectFontsToPreload: (_family, fonts) => fonts,
+      resolveFontFace: () => ({
+        fonts: [{ src: [{ url: '/poppins.woff2', format: 'woff2' }] }],
+        fallbacks: ['Arial'],
+        skipFontFaceGeneration: true,
+      }),
+    })
+
+    expect(fontsToPreload.size).toBe(0)
+  })
+
   it('should minify generated declarations outside dev', async () => {
     const result = await transform(`:root { font-family: 'Inter' }`, { dev: false })
 

--- a/packages/fontless/test/utils.spec.ts
+++ b/packages/fontless/test/utils.spec.ts
@@ -46,12 +46,12 @@ describe('transformCSS', () => {
     expect(fontsToPreload.size).toBe(0)
   })
 
-  it('should emit fallbacks without the primary `@font-face` when `skipFontFaceGeneration` is set', async () => {
+  it('should emit fallbacks without the primary `@font-face` when `fallbacksOnly` is set', async () => {
     const result = await transform(`:root { font-family: 'Poppins' }`, {
       resolveFontFace: () => ({
         fonts: [{ src: [{ url: '/poppins.woff2', format: 'woff2' }] }],
         fallbacks: ['Arial'],
-        skipFontFaceGeneration: true,
+        fallbacksOnly: true,
       }),
     })
 
@@ -73,7 +73,7 @@ describe('transformCSS', () => {
     expect(result).toContain(`font-family: 'Poppins', "Poppins Fallback: Arial"`)
   })
 
-  it('should not register preloads when `skipFontFaceGeneration` is set', async () => {
+  it('should not register preloads when `fallbacksOnly` is set', async () => {
     const fontsToPreload = new Map<string, Set<string>>()
     await transform(`:root { font-family: 'Poppins' }`, {
       fontsToPreload,
@@ -81,11 +81,24 @@ describe('transformCSS', () => {
       resolveFontFace: () => ({
         fonts: [{ src: [{ url: '/poppins.woff2', format: 'woff2' }] }],
         fallbacks: ['Arial'],
-        skipFontFaceGeneration: true,
+        fallbacksOnly: true,
       }),
     })
 
     expect(fontsToPreload.size).toBe(0)
+  })
+
+  it('should leave usage sites untouched when `fallbacksOnly` is set and no fallbacks resolve', async () => {
+    const result = await transform(`:root { font-family: 'Poppins' }`, {
+      resolveFontFace: () => ({
+        fonts: [{ src: [{ url: '/poppins.woff2', format: 'woff2' }] }],
+        fallbacks: [],
+        fallbacksOnly: true,
+      }),
+    })
+
+    expect(result).not.toContain('@font-face')
+    expect(result).toBe(`:root { font-family: 'Poppins' }`)
   })
 
   it('should minify generated declarations outside dev', async () => {

--- a/packages/fontless/test/vite.spec.ts
+++ b/packages/fontless/test/vite.spec.ts
@@ -106,6 +106,25 @@ describe('fontless vite plugin', () => {
     expect(output).toContain('font-family:Poppins;src:')
   })
 
+  it('should inject nothing when a `global` family resolves to no fonts', async () => {
+    const root = await createFixture({ 'index.html': html, 'style.css': styles })
+    const { html: output } = await buildApp(root, {
+      families: [{ name: 'Inter', global: true, provider: 'none' }],
+    })
+
+    expect(output).not.toContain('<style')
+  })
+
+  it('should not preload `global` fonts that have no remote source', async () => {
+    const root = await createFixture({ 'index.html': html, 'style.css': styles })
+    const { html: output } = await buildApp(root, {
+      families: [{ name: 'Inter', global: true, preload: true, src: [{ name: 'Inter Var' }] }],
+    })
+
+    expect(output).toContain('local(Inter Var)')
+    expect(output).not.toContain('rel="preload"')
+  })
+
   it('should still add fallback metrics at usage sites for `global` families', async () => {
     const root = await createFixture({ 'index.html': html, 'style.css': styles })
     const { css } = await buildApp(root, {

--- a/packages/fontless/test/vite.spec.ts
+++ b/packages/fontless/test/vite.spec.ts
@@ -63,8 +63,14 @@ async function buildApp(root: string, options: FontlessOptions = {}, config: Inl
 
   const files = await Array.fromAsync(fsp.glob('**/*', { cwd: outDir }))
   const cssFile = files.find(file => file.endsWith('.css'))
+  const htmlFile = files.find(file => file.endsWith('.html'))
 
-  return { outDir, files, css: cssFile ? await fsp.readFile(join(outDir, cssFile), 'utf-8') : '' }
+  return {
+    outDir,
+    files,
+    css: cssFile ? await fsp.readFile(join(outDir, cssFile), 'utf-8') : '',
+    html: htmlFile ? await fsp.readFile(join(outDir, htmlFile), 'utf-8') : '',
+  }
 }
 
 describe('fontless vite plugin', () => {
@@ -75,11 +81,47 @@ describe('fontless vite plugin', () => {
     expect(css).toContain('@font-face')
   })
 
-  it('should not inject `@font-face` for families declared `global`', async () => {
+  it('should inject `@font-face` into the HTML for families declared `global`', async () => {
     const root = await createFixture({ 'index.html': html, 'style.css': styles })
-    const { css } = await buildApp(root, { families: [{ name: 'Inter', global: true }] })
+    const { css, html: output } = await buildApp(root, { families: [{ name: 'Inter', global: true }] })
 
-    expect(css).not.toContain('@font-face')
+    expect(css).not.toContain('font-family:Inter;src:')
+    expect(output).toContain('<style type="text/css">@font-face{font-family:Inter;src:')
+  })
+
+  it('should emit fonts referenced only by the global `@font-face` declarations', async () => {
+    const root = await createFixture({ 'index.html': html, 'style.css': `body { color: red }` })
+    const src = pathToFileURL(join(root, 'inter.woff2')).href
+    const { html: output, files } = await buildApp(root, { families: [{ name: 'Inter', global: true, src }] })
+
+    const font = files.find(file => file.includes('_fonts/'))
+    expect(font).toBeDefined()
+    expect(output).toContain(`/${font}`)
+  })
+
+  it('should inject `@font-face` for a `global` family that is never used in CSS', async () => {
+    const root = await createFixture({ 'index.html': html, 'style.css': `body { color: red }` })
+    const { html: output } = await buildApp(root, { families: [{ name: 'Poppins', global: true }] })
+
+    expect(output).toContain('font-family:Poppins;src:')
+  })
+
+  it('should still add fallback metrics at usage sites for `global` families', async () => {
+    const root = await createFixture({ 'index.html': html, 'style.css': styles })
+    const { css } = await buildApp(root, {
+      families: [{ name: 'Inter', global: true, fallbacks: ['Arial'] }],
+    })
+
+    expect(css).toContain('Inter Fallback\\: Arial')
+  })
+
+  it('should preload fonts for `global` families', async () => {
+    const root = await createFixture({ 'index.html': html, 'style.css': `body { color: red }` })
+    const { html: output } = await buildApp(root, {
+      families: [{ name: 'Inter', global: true, preload: true }],
+    })
+
+    expect(output).toContain('rel="preload"')
   })
 
   it('should minify generated declarations with lightningcss when configured', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   '@nuxt/fonts>fontaine': latest
-  '@nuxt/fonts>fontless': latest
+  '@nuxt/fonts>fontless': ^0.2.1
   fontaine: workspace:*
   fontless: workspace:*
   unstorage: 1.17.5
@@ -1723,6 +1723,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.28.2':
     resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
     engines: {node: '>=18'}
@@ -1737,6 +1743,12 @@ packages:
 
   '@esbuild/android-arm64@0.25.9':
     resolution: {integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -1759,6 +1771,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-arm@0.28.2':
     resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
     engines: {node: '>=18'}
@@ -1773,6 +1791,12 @@ packages:
 
   '@esbuild/android-x64@0.25.9':
     resolution: {integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -1795,6 +1819,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.28.2':
     resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
     engines: {node: '>=18'}
@@ -1809,6 +1839,12 @@ packages:
 
   '@esbuild/darwin-x64@0.25.9':
     resolution: {integrity: sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1831,6 +1867,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.28.2':
     resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
     engines: {node: '>=18'}
@@ -1845,6 +1887,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.25.9':
     resolution: {integrity: sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -1867,6 +1915,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.28.2':
     resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
     engines: {node: '>=18'}
@@ -1881,6 +1935,12 @@ packages:
 
   '@esbuild/linux-arm@0.25.9':
     resolution: {integrity: sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -1903,6 +1963,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.28.2':
     resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
     engines: {node: '>=18'}
@@ -1917,6 +1983,12 @@ packages:
 
   '@esbuild/linux-loong64@0.25.9':
     resolution: {integrity: sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1939,6 +2011,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.28.2':
     resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
     engines: {node: '>=18'}
@@ -1953,6 +2031,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.25.9':
     resolution: {integrity: sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1975,6 +2059,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.28.2':
     resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
     engines: {node: '>=18'}
@@ -1989,6 +2079,12 @@ packages:
 
   '@esbuild/linux-s390x@0.25.9':
     resolution: {integrity: sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -2011,6 +2107,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.28.2':
     resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
     engines: {node: '>=18'}
@@ -2025,6 +2127,12 @@ packages:
 
   '@esbuild/netbsd-arm64@0.25.9':
     resolution: {integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -2047,6 +2155,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.28.2':
     resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
     engines: {node: '>=18'}
@@ -2061,6 +2175,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.25.9':
     resolution: {integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -2083,6 +2203,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openbsd-x64@0.28.2':
     resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
     engines: {node: '>=18'}
@@ -2097,6 +2223,12 @@ packages:
 
   '@esbuild/openharmony-arm64@0.25.9':
     resolution: {integrity: sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -2119,6 +2251,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.28.2':
     resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
     engines: {node: '>=18'}
@@ -2133,6 +2271,12 @@ packages:
 
   '@esbuild/win32-arm64@0.25.9':
     resolution: {integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -2155,6 +2299,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.28.2':
     resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
     engines: {node: '>=18'}
@@ -2169,6 +2319,12 @@ packages:
 
   '@esbuild/win32-x64@0.25.9':
     resolution: {integrity: sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -7564,6 +7720,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esbuild@0.28.2:
     resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
     engines: {node: '>=18'}
@@ -8014,9 +8175,9 @@ packages:
     resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
     engines: {node: '>=20'}
 
-  fontless@0.4.0:
-    resolution: {integrity: sha512-s579YVgJJk0d49WQaWBj4YSflOg3qFF78/y0dCNbCgIsGhoSnnr1p1Vrgrj5Vj12fTZMk8KBJI9cZ27eOUEXww==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  fontless@0.2.1:
+    resolution: {integrity: sha512-mUWZ8w91/mw2KEcZ6gHNoNNmsAq9Wiw2IypIux5lM03nhXm+WSloXGUNuRETNTLqZexMgpt7Aj/v63qqrsWraQ==}
+    engines: {node: '>=18.12.0'}
     peerDependencies:
       vite: '*'
     peerDependenciesMeta:
@@ -14254,6 +14415,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.9':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
   '@esbuild/aix-ppc64@0.28.2':
     optional: true
 
@@ -14261,6 +14425,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm64@0.28.2':
@@ -14272,6 +14439,9 @@ snapshots:
   '@esbuild/android-arm@0.25.9':
     optional: true
 
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
   '@esbuild/android-arm@0.28.2':
     optional: true
 
@@ -14279,6 +14449,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.25.9':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/android-x64@0.28.2':
@@ -14290,6 +14463,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.25.9':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
   '@esbuild/darwin-arm64@0.28.2':
     optional: true
 
@@ -14297,6 +14473,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.25.9':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-x64@0.28.2':
@@ -14308,6 +14487,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.25.9':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.28.2':
     optional: true
 
@@ -14315,6 +14497,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.2':
@@ -14326,6 +14511,9 @@ snapshots:
   '@esbuild/linux-arm64@0.25.9':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
   '@esbuild/linux-arm64@0.28.2':
     optional: true
 
@@ -14333,6 +14521,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.25.9':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-arm@0.28.2':
@@ -14344,6 +14535,9 @@ snapshots:
   '@esbuild/linux-ia32@0.25.9':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
   '@esbuild/linux-ia32@0.28.2':
     optional: true
 
@@ -14351,6 +14545,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-loong64@0.28.2':
@@ -14362,6 +14559,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.25.9':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
   '@esbuild/linux-mips64el@0.28.2':
     optional: true
 
@@ -14369,6 +14569,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.2':
@@ -14380,6 +14583,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.25.9':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
   '@esbuild/linux-riscv64@0.28.2':
     optional: true
 
@@ -14387,6 +14593,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.25.9':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-s390x@0.28.2':
@@ -14398,6 +14607,9 @@ snapshots:
   '@esbuild/linux-x64@0.25.9':
     optional: true
 
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
   '@esbuild/linux-x64@0.28.2':
     optional: true
 
@@ -14405,6 +14617,9 @@ snapshots:
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.2':
@@ -14416,6 +14631,9 @@ snapshots:
   '@esbuild/netbsd-x64@0.25.9':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/netbsd-x64@0.28.2':
     optional: true
 
@@ -14423,6 +14641,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.2':
@@ -14434,6 +14655,9 @@ snapshots:
   '@esbuild/openbsd-x64@0.25.9':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
   '@esbuild/openbsd-x64@0.28.2':
     optional: true
 
@@ -14441,6 +14665,9 @@ snapshots:
     optional: true
 
   '@esbuild/openharmony-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.2':
@@ -14452,6 +14679,9 @@ snapshots:
   '@esbuild/sunos-x64@0.25.9':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
   '@esbuild/sunos-x64@0.28.2':
     optional: true
 
@@ -14459,6 +14689,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
   '@esbuild/win32-arm64@0.28.2':
@@ -14470,6 +14703,9 @@ snapshots:
   '@esbuild/win32-ia32@0.25.9':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
   '@esbuild/win32-ia32@0.28.2':
     optional: true
 
@@ -14477,6 +14713,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.25.9':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@esbuild/win32-x64@0.28.2':
@@ -15695,7 +15934,7 @@ snapshots:
       '@nuxt/kit': 4.5.2(magic-string@1.2.2)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.46.0)(yaml@2.9.0))(webpack@5.105.0(@swc/core@1.16.0(@swc/helpers@0.5.19))(esbuild@0.28.2)))
       consola: 3.4.2
       defu: 6.1.7
-      fontless: 0.4.0(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.46.0)(yaml@2.9.0))
+      fontless: 0.2.1(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.46.0)(yaml@2.9.0))
       h3: 1.15.11
       magic-regexp: 0.10.0
       ofetch: 1.5.1
@@ -19992,6 +20231,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.9
       '@esbuild/win32-x64': 0.25.9
 
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
   esbuild@0.28.2:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.28.2
@@ -20605,20 +20873,20 @@ snapshots:
     dependencies:
       tiny-inflate: 1.0.3
 
-  fontless@0.4.0(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.46.0)(yaml@2.9.0)):
+  fontless@0.2.1(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.46.0)(yaml@2.9.0)):
     dependencies:
       consola: 3.4.2
       css-tree: 3.2.1
       defu: 6.1.7
-      exsolve: 1.1.1
+      esbuild: 0.27.7
       fontaine: link:packages/fontaine
       jiti: 2.7.0
       lightningcss: 1.33.0
-      magic-string: 1.2.2
+      magic-string: 0.30.21
       ohash: 2.0.12
       pathe: 2.0.3
       ufo: 1.6.4
-      unifont: 0.8.3
+      unifont: 0.7.5
       unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))
     optionalDependencies:
       vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(less@4.4.0)(sass@1.90.0)(terser@5.46.0)(yaml@2.9.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,10 @@ packages:
 
 overrides:
   '@nuxt/fonts>fontaine': latest
-  '@nuxt/fonts>fontless': latest
+  # `fontless: workspace:*` below would otherwise link the workspace copy into
+  # `@nuxt/fonts`, which depends on `fontless@^0.2.1`. `latest` broke once 0.3.0 dropped
+  # `resolveMinifyCssEsbuildOptions`, so track the range `@nuxt/fonts` declares instead.
+  '@nuxt/fonts>fontless': ^0.2.1
   fontaine: 'workspace:*'
   fontless: 'workspace:*'
   unstorage: 1.17.5


### PR DESCRIPTION
`global: true` has been in the types since the port from nuxt/fonts, and documented as injecting font data regardless of usage.

... but in fact it doesn't seem ever to have worked. `resolveFontFace` returns early for those families so nothing happened at all.

this PR now resolves global families up front from config rather than discovering them from CSS, and their `@font-face` is inlined into a `<style>` tag in `<head>` via `transformIndexHtml`:

```ts
fontless({
  families: [
    { name: 'Inter', global: true },
  ],
})
```

usage sites that _do_ appear in CSS still get their fallbacks.

two side effects:

1. preloads work for these families now. they never reached `fontsToPreload` before, since we returned before resolving. they also work on the first `vite dev` render, unlike preloads discovered from stylesheets, because global families come from config.
2. global fonts aren't reachable from any module, so they can't go through vite's asset pipeline, so they get plain public URLs and are emitted from `generateBundle` instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added global font-face support with preloading, asset emission, HTML injection, and runtime access for SSR.
  - Added glyph subsetting for provider and local fonts, with configurable caching and proxy settings.
  - Added fallback-only font generation while preserving metric fallbacks and usage-site behavior.

- **Documentation**
  - Documented glyph subsetting, global font faces, Vite behavior, caching, licensing, and SSR usage.

- **Refactor**
  - Improved declaration rendering and clarified fallback-generation configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->