### PR TITLE
feat(fontless): identify preload font families

### DIFF
--- a/packages/fontless/src/runtime.ts
+++ b/packages/fontless/src/runtime.ts
@@ -19,10 +19,11 @@ export const preloads: LinkAttributes[] = []
 export const globalFontFaces: string = ''
 
 export interface LinkAttributes {
-  rel: 'preload'
-  as: 'font'
-  href: string
-  crossorigin: 'anonymous' | 'use-credentials' | '' | undefined
+  'rel': 'preload'
+  'as': 'font'
+  'href': string
+  'crossorigin': 'anonymous' | 'use-credentials' | '' | undefined
+  'data-font-family': string
 }
 
 // Reaching this module at runtime means the plugin did not replace it, so the import

--- a/packages/fontless/src/utils.ts
+++ b/packages/fontless/src/utils.ts
@@ -38,6 +38,7 @@ export interface FontFamilyInjectionPluginOptions {
   processCSSVariables?: boolean | 'font-prefixed-only' | (string & {})
   selectFontsToPreload?: (fontFamily: string, fonts: FontFaceData[]) => FontFaceData[]
   fontsToPreload: Map<string, Set<string>>
+  preloadFamilies?: Map<string, Map<string, string>>
 }
 
 function findSafeInsertionIndex(ast: CssNode): number {
@@ -129,6 +130,10 @@ export async function transformCSS(options: FontFamilyInjectionPluginOptions, co
       if (fontToPreload) {
         const urls = options.fontsToPreload.get(id) || new Set()
         options.fontsToPreload.set(id, urls.add(fontToPreload))
+        if (options.preloadFamilies) {
+          const families = options.preloadFamilies.get(id) || new Map()
+          options.preloadFamilies.set(id, families.set(fontToPreload, fontFamily))
+        }
       }
     }
 

--- a/packages/fontless/src/vite.ts
+++ b/packages/fontless/src/vite.ts
@@ -123,8 +123,10 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
     return []
   }
 
-  function getPreloadHrefs() {
-    return [...cssTransformOptions.fontsToPreload.values()].flatMap(v => [...v])
+  function getPreloads() {
+    return [...cssTransformOptions.fontsToPreload.entries()].flatMap(([id, hrefs]) =>
+      [...hrefs].map(href => [href, cssTransformOptions.preloadFamilies!.get(id)!.get(href)!] as [string, string]),
+    )
   }
 
   // Fonts referenced only by the global stylesheet, which is not attached to any module
@@ -144,6 +146,7 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
       const families = options.families?.filter(f => f.global) ?? []
       const declarations: string[] = []
       const hrefs = new Set<string>()
+      const preloadFamilies = new Map<string, string>()
 
       for (const family of families) {
         const result = await buildContext.run(
@@ -159,6 +162,7 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
           const url = font.src.find((s): s is RemoteFontSource => 'url' in s)?.url
           if (url) {
             hrefs.add(url)
+            preloadFamilies.set(url, family.name)
           }
         }
 
@@ -171,6 +175,7 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
 
       if (hrefs.size > 0) {
         cssTransformOptions.fontsToPreload.set(GLOBAL_CSS_ID, hrefs)
+        cssTransformOptions.preloadFamilies!.set(GLOBAL_CSS_ID, preloadFamilies)
       }
 
       return declarations.join('')
@@ -204,12 +209,13 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
     return globalAssetURLs.reduce((value, [from, to]) => value.replaceAll(from, to), value)
   }
 
-  function toPreloadLinks(hrefs: string[]): LinkAttributes[] {
-    return hrefs.map(href => ({
-      rel: 'preload',
-      as: 'font',
+  function toPreloadLinks(preloads: Array<[string, string]>): LinkAttributes[] {
+    return preloads.map(([href, fontFamily]) => ({
+      'rel': 'preload',
+      'as': 'font',
       href,
-      crossorigin: '',
+      'crossorigin': '',
+      'data-font-family': fontFamily,
     }))
   }
 
@@ -274,6 +280,7 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
         processCSSVariables: options.processCSSVariables,
         selectFontsToPreload,
         fontsToPreload: new Map(),
+        preloadFamilies: new Map(),
         dev: config.mode === 'development',
         async resolveFontFace(fontFamily, fallbackOptions) {
           const override = options.families?.find(f => f.name === fontFamily)
@@ -382,7 +389,9 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
         // resolved here rather than discovered.
         const css = withEmittedAssets(await getGlobalFontFaces())
 
-        const tags = toPreloadLinks(getPreloadHrefs().map(withEmittedAssets)).map(attrs => ({
+        const preloads = getPreloads()
+          .map(([href, family]) => [withEmittedAssets(href), family] as [string, string])
+        const tags = toPreloadLinks(preloads).map(attrs => ({
           tag: 'link',
           attrs: attrs as unknown as Record<string, string>,
         }))
@@ -397,7 +406,8 @@ export function fontless(_options?: FontlessOptions): Plugin[] {
   }
 
   function getRuntimePreloads(): LinkAttributes[] {
-    return toPreloadLinks(getPreloadHrefs().map(href => publicFontURLs.get(href) ?? href))
+    return toPreloadLinks(getPreloads()
+      .map(([href, family]) => [publicFontURLs.get(href) ?? href, family] as [string, string]))
   }
 
   async function getRuntimeExports() {

--- a/packages/fontless/test/runtime.spec.ts
+++ b/packages/fontless/test/runtime.spec.ts
@@ -87,6 +87,7 @@ describe('`fontless/runtime` in build', () => {
     expect(chunk).not.toContain('__FONTLESS_RUNTIME_BUILD_PLACEHOLDER__')
     expect(chunk).not.toContain('__VITE_ASSET__')
     expect(chunk).toMatch(/rel:["'`]preload/)
+    expect(chunk).toMatch(/data-font-family:["'`]Poppins/)
     expect(hrefs.length).toBeGreaterThan(0)
     for (const href of hrefs) {
       expect(files).toContain(join('assets/_fonts', href.split('/_fonts/')[1]!))
@@ -135,7 +136,12 @@ describe('`fontless/runtime` in dev', () => {
 
       const after = await server.ssrLoadModule('fontless/runtime')
       expect(after.preloads.length).toBeGreaterThan(0)
-      expect(after.preloads[0]).toMatchObject({ rel: 'preload', as: 'font', crossorigin: '' })
+      expect(after.preloads[0]).toMatchObject({
+        'rel': 'preload',
+        'as': 'font',
+        'crossorigin': '',
+        'data-font-family': 'Poppins',
+      })
       expect(after.preloads[0].href).toMatch(/\/assets\/_fonts\/.*\.woff2$/)
     }
     finally {

--- a/packages/fontless/test/vite.spec.ts
+++ b/packages/fontless/test/vite.spec.ts
@@ -141,6 +141,7 @@ describe('fontless vite plugin', () => {
     })
 
     expect(output).toContain('rel="preload"')
+    expect(output).toContain('data-font-family="Inter"')
   })
 
   it('should minify generated declarations with lightningcss when configured', async () => {


### PR DESCRIPTION
Fixes #817.

Each generated preload link now includes `data-font-family`, so runtime consumers and HTML hooks can filter preloads by the configured family without parsing generated asset URLs.

Validation:

- `pnpm --filter fontless test:types`
- focused runtime preload and global HTML preload tests
- ESLint and `git diff --check`

The wider runtime and Vite build group still hits its existing font-asset discovery failures on this Windows Node 24 setup, after the relevant preload output is generated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Font preload links now include the associated font family name through a `data-font-family` attribute.
  * The font family metadata is preserved consistently in both development and production-generated HTML.

* **Tests**
  * Added coverage verifying font family attributes for preloaded fonts, including Poppins and Inter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->