### PR TITLE
feat(fontless): support font metric override descriptors

### DIFF
--- a/packages/fontless/src/assets.ts
+++ b/packages/fontless/src/assets.ts
@@ -64,7 +64,7 @@ export interface NormalizeFontDataContext {
 
 export function normalizeFontData(context: NormalizeFontDataContext, faces: RawFontFaceData | FontFaceData[], options: NormalizeFontDataOptions = {}): FontFaceData[] {
   const data: FontFaceData[] = []
-  for (const face of toArray(faces)) {
+  for (const face of toArray<RawFontFaceData | FontFaceData>(faces)) {
     let subsetted = false
     const unicodeRange = toArray(face.unicodeRange)
     const src = toArray(face.src).map((src) => {

--- a/packages/fontless/src/css/render.ts
+++ b/packages/fontless/src/css/render.ts
@@ -39,6 +39,10 @@ type FallbackMetrics = Pick<Required<ProviderFontMetrics>, 'ascent' | 'descent' 
 
 const OPTIONAL_METRICS = ['ascent', 'descent', 'lineGap', 'capHeight', 'xHeight', 'xWidthAvg'] as const
 
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
 /**
  * Metrics reported by the provider that resolved this face, if any. Not every version of
  * `unifont` returns them, so the shape is validated before use.
@@ -49,13 +53,14 @@ function readProviderMetrics(data: NormalizedFontFaceData): ProviderFontMetrics 
     return
   }
   const metrics = candidate as Record<string, unknown>
-  if (typeof metrics.unitsPerEm !== 'number' || !metrics.unitsPerEm) {
+  if (!isFiniteNumber(metrics.unitsPerEm) || metrics.unitsPerEm <= 0) {
     return
   }
   const result: ProviderFontMetrics = { unitsPerEm: metrics.unitsPerEm }
   for (const key of OPTIONAL_METRICS) {
-    if (typeof metrics[key] === 'number') {
-      result[key] = metrics[key]
+    const value = metrics[key]
+    if (isFiniteNumber(value)) {
+      result[key] = value
     }
   }
   return result

--- a/packages/fontless/src/css/render.ts
+++ b/packages/fontless/src/css/render.ts
@@ -1,10 +1,10 @@
-import type { FontFaceData, RemoteFontSource } from 'unifont'
-import type { FontSource } from '../types'
+import type { RemoteFontSource } from 'unifont'
+import type { FontSource, NormalizedFontFaceData } from '../types'
 import { generateFontFace as generateFallbackFontFace, getMetricsForFamily, readMetrics } from 'fontaine'
 import { extname, relative } from 'pathe'
 import { hasProtocol } from 'ufo'
 
-export function generateFontFace(family: string, font: FontFaceData): string {
+export function generateFontFace(family: string, font: NormalizedFontFaceData): string {
   return [
     '@font-face {',
     `  font-family: '${family}';`,
@@ -16,16 +16,90 @@ export function generateFontFace(family: string, font: FontFaceData): string {
     font.stretch && `  font-stretch: ${font.stretch};`,
     font.featureSettings && `  font-feature-settings: ${font.featureSettings};`,
     font.variationSettings && `  font-variation-settings: ${font.variationSettings};`,
+    font.ascentOverride && `  ascent-override: ${font.ascentOverride};`,
+    font.descentOverride && `  descent-override: ${font.descentOverride};`,
+    font.lineGapOverride && `  line-gap-override: ${font.lineGapOverride};`,
+    font.sizeAdjust && `  size-adjust: ${font.sizeAdjust};`,
     `}`,
   ].filter(Boolean).join('\n')
 }
 
-export async function generateFontFallbacks(family: string, data: FontFaceData, fallbacks?: Array<{ name: string, font: string }>): Promise<string[]> {
+/** Metrics a provider may report for a face. Only `unitsPerEm` is guaranteed to be present. */
+interface ProviderFontMetrics {
+  unitsPerEm: number
+  ascent?: number
+  descent?: number
+  lineGap?: number
+  capHeight?: number
+  xHeight?: number
+  xWidthAvg?: number
+}
+
+type FallbackMetrics = Pick<Required<ProviderFontMetrics>, 'ascent' | 'descent' | 'lineGap' | 'unitsPerEm' | 'xWidthAvg'>
+
+const OPTIONAL_METRICS = ['ascent', 'descent', 'lineGap', 'capHeight', 'xHeight', 'xWidthAvg'] as const
+
+/**
+ * Metrics reported by the provider that resolved this face, if any. Not every version of
+ * `unifont` returns them, so the shape is validated before use.
+ */
+function readProviderMetrics(data: NormalizedFontFaceData): ProviderFontMetrics | undefined {
+  const candidate = (data as { metrics?: unknown }).metrics
+  if (!candidate || typeof candidate !== 'object') {
+    return
+  }
+  const metrics = candidate as Record<string, unknown>
+  if (typeof metrics.unitsPerEm !== 'number' || !metrics.unitsPerEm) {
+    return
+  }
+  const result: ProviderFontMetrics = { unitsPerEm: metrics.unitsPerEm }
+  for (const key of OPTIONAL_METRICS) {
+    if (typeof metrics[key] === 'number') {
+      result[key] = metrics[key]
+    }
+  }
+  return result
+}
+
+/**
+ * Complete a provider's metrics into the set the fallback faces are derived from, filling gaps
+ * from the metrics database where the family is known there.
+ *
+ * `ascent`, `descent` and `lineGap` are all needed, since each is divided by the em square to
+ * produce one of the `*-override` descriptors. `xWidthAvg` only drives `size-adjust`, and zero
+ * leaves the fallback at its natural width. Database values are in that font's own em square, so
+ * they are scaled into the provider's before being mixed in.
+ */
+function resolveProviderMetrics(data: NormalizedFontFaceData, knownMetrics: FallbackMetrics | null): FallbackMetrics | undefined {
+  const metrics = readProviderMetrics(data)
+  if (!metrics) {
+    return
+  }
+  const scale = knownMetrics ? metrics.unitsPerEm / knownMetrics.unitsPerEm : 0
+  const fill = (key: keyof FallbackMetrics) => knownMetrics ? knownMetrics[key] * scale : undefined
+
+  const ascent = metrics.ascent ?? fill('ascent')
+  const descent = metrics.descent ?? fill('descent')
+  const lineGap = metrics.lineGap ?? fill('lineGap')
+  if (ascent === undefined || descent === undefined || lineGap === undefined) {
+    return
+  }
+  return {
+    ascent,
+    descent,
+    lineGap,
+    unitsPerEm: metrics.unitsPerEm,
+    xWidthAvg: metrics.xWidthAvg ?? fill('xWidthAvg') ?? 0,
+  }
+}
+
+export async function generateFontFallbacks(family: string, data: NormalizedFontFaceData, fallbacks?: Array<{ name: string, font: string }>): Promise<string[]> {
   if (!fallbacks?.length)
     return []
 
   const fontURL = data.src!.find(s => 'url' in s) as RemoteFontSource | undefined
-  const metrics = await getMetricsForFamily(family) || (fontURL && await readMetrics(fontURL.originalURL || fontURL.url))
+  const knownMetrics = await getMetricsForFamily(family)
+  const metrics = resolveProviderMetrics(data, knownMetrics) || knownMetrics || (fontURL && await readMetrics(fontURL.originalURL || fontURL.url))
 
   if (!metrics)
     return []
@@ -89,7 +163,7 @@ function renderFontSrc(sources: Exclude<FontSource, string>[]) {
   }).join(', ')
 }
 
-export function relativiseFontSources(font: FontFaceData, relativeTo: string): FontFaceData {
+export function relativiseFontSources(font: NormalizedFontFaceData, relativeTo: string): NormalizedFontFaceData {
   return {
     ...font,
     src: font.src.map((source) => {
@@ -102,5 +176,5 @@ export function relativiseFontSources(font: FontFaceData, relativeTo: string): F
         url: relative(relativeTo, source.url),
       }
     }),
-  } satisfies FontFaceData
+  } satisfies NormalizedFontFaceData
 }

--- a/packages/fontless/src/resolve.ts
+++ b/packages/fontless/src/resolve.ts
@@ -1,7 +1,7 @@
 import type { ConsolaInstance } from 'consola'
 import type { FontFaceData, Provider, UnifontOptions } from 'unifont'
 import type { GenericCSSFamily } from './css/parse'
-import type { FontFamilyManualOverride, FontFamilyProviderOverride, FontlessOptions, ManualFontDetails, ProviderFamilyOptions, ProviderFontDetails, RawFontFaceData } from './types'
+import type { FontFamilyManualOverride, FontFamilyProviderOverride, FontlessOptions, ManualFontDetails, NormalizedFontFaceData, ProviderFamilyOptions, ProviderFontDetails, RawFontFaceData } from './types'
 
 import type { FontFaceResolution } from './utils'
 import { consola } from 'consola'
@@ -62,18 +62,29 @@ function toArray<T>(value: T | T[]): T[] {
   return Array.isArray(value) ? value : [value]
 }
 
+const METRIC_OVERRIDE_KEYS = ['ascentOverride', 'descentOverride', 'lineGapOverride', 'sizeAdjust'] as const
+
 /** Apply family-level `@font-face` descriptors to faces resolved by a provider. */
-function applyFaceOverrides(override: FontFamilyManualOverride | FontFamilyProviderOverride | undefined, fonts: FontFaceData[]): FontFaceData[] {
+function applyFaceOverrides(override: FontFamilyManualOverride | FontFamilyProviderOverride | undefined, fonts: FontFaceData[]): NormalizedFontFaceData[] {
   const display = override && 'display' in override ? override.display : undefined
   const rawUnicodeRange = override && 'unicodeRange' in override ? override.unicodeRange : undefined
   const unicodeRange = rawUnicodeRange ? toArray(rawUnicodeRange) : undefined
-  if (!display && !unicodeRange) {
+  const metricOverrides: Record<string, string> = {}
+  for (const key of METRIC_OVERRIDE_KEYS) {
+    const value = override?.[key]
+    if (value) {
+      metricOverrides[key] = value
+    }
+  }
+  const hasMetricOverrides = Object.keys(metricOverrides).length > 0
+  if (!display && !unicodeRange && !hasMetricOverrides) {
     return fonts
   }
   return fonts.map(font => ({
     ...font,
     ...(display && { display }),
     ...(unicodeRange && { unicodeRange }),
+    ...metricOverrides,
   }))
 }
 

--- a/packages/fontless/src/types.ts
+++ b/packages/fontless/src/types.ts
@@ -26,13 +26,20 @@ export interface ProviderFontDetails extends SharedFontDetails {
   provider: string
 }
 
-// TODO: Font metric providers
-// export interface FontFaceAdjustments {
-//   ascentOverride?: string // ascent-override
-//   descentOverride?: string // descent-override
-//   lineGapOverride?: string // line-gap-override
-//   sizeAdjust?: string // size-adjust
-// }
+/** CSS font metric override descriptors. */
+interface FontFaceMetricOverrides {
+  /** `ascent-override` descriptor. */
+  ascentOverride?: string
+  /** `descent-override` descriptor. */
+  descentOverride?: string
+  /** `line-gap-override` descriptor. */
+  lineGapOverride?: string
+  /** `size-adjust` descriptor. */
+  sizeAdjust?: string
+}
+
+/** Font face data with the descriptors `fontless` supports on top of those `unifont` resolves. */
+export type NormalizedFontFaceData = FontFaceData & FontFaceMetricOverrides
 
 export type FontProviderName = (string & {}) | 'google' | 'local' | 'none'
 
@@ -69,7 +76,7 @@ export type ProviderFamilyOptions = {
   googleicons?: GoogleiconsFamilyOptions
 } & Record<string, Record<string, unknown> | undefined>
 
-export interface FontFamilyProviderOverride extends FontFamilyOverrides, Partial<Omit<ResolveFontOptions, 'weights' | 'options'> & { weights: Array<string | number> }> {
+export interface FontFamilyProviderOverride extends FontFamilyOverrides, FontFaceMetricOverrides, Partial<Omit<ResolveFontOptions, 'weights' | 'options'> & { weights: Array<string | number> }> {
   /** The provider to use when resolving this font. */
   provider?: FontProviderName
   /**
@@ -85,7 +92,7 @@ export interface FontFamilyProviderOverride extends FontFamilyOverrides, Partial
 
 export type FontSource = string | LocalFontSource | RemoteFontSource
 
-export interface RawFontFaceData extends Omit<FontFaceData, 'src' | 'unicodeRange'> {
+export interface RawFontFaceData extends Omit<FontFaceData, 'src' | 'unicodeRange'>, FontFaceMetricOverrides {
   src: FontSource | Array<FontSource>
   unicodeRange?: string | string[]
 }

--- a/packages/fontless/src/utils.ts
+++ b/packages/fontless/src/utils.ts
@@ -2,7 +2,7 @@ import type { CssNode, StyleSheet } from 'css-tree'
 import type { TransformOptions as LightningCSSTransformOptions } from 'lightningcss'
 import type { FontFaceData, RemoteFontSource } from 'unifont'
 import type { GenericCSSFamily } from './css/parse'
-import type { Awaitable } from './types'
+import type { Awaitable, NormalizedFontFaceData } from './types'
 import { Buffer } from 'node:buffer'
 import { consola } from 'consola'
 import { parse, walk } from 'css-tree'
@@ -17,7 +17,7 @@ import { generateFontFace, generateFontFallbacks, relativiseFontSources } from '
 const logger = consola.withTag('fontless')
 
 export interface FontFaceResolution {
-  fonts?: FontFaceData[]
+  fonts?: NormalizedFontFaceData[]
   fallbacks?: string[]
   /**
    * Emit only the fallback metric faces, not the primary `@font-face`, and register

--- a/packages/fontless/test/render.spec.ts
+++ b/packages/fontless/test/render.spec.ts
@@ -62,6 +62,26 @@ describe('rendering @font-face', () => {
       }"
     `)
   })
+  it('should render metric override descriptors', () => {
+    const css = generateFontFace('Inter', {
+      src: [{ url: '/inter.woff2' }],
+      ascentOverride: '90%',
+      descentOverride: '20%',
+      lineGapOverride: '0%',
+      sizeAdjust: '105%',
+    })
+    expect(css).toMatchInlineSnapshot(`
+      "@font-face {
+        font-family: 'Inter';
+        src: url("/inter.woff2");
+        font-display: swap;
+        ascent-override: 90%;
+        descent-override: 20%;
+        line-gap-override: 0%;
+        size-adjust: 105%;
+      }"
+    `)
+  })
   it('should render feature and variation settings', () => {
     const css = generateFontFace('Inter', {
       src: [{ url: '/inter.woff2' }],
@@ -97,6 +117,67 @@ describe('generateFontFallbacks', () => {
 
   it('should generate no fallbacks when none are requested', async () => {
     expect(await generateFontFallbacks('Inter', { src: [{ url: '/inter.woff2' }] })).toEqual([])
+  })
+
+  it('should use metrics reported by the provider', async () => {
+    const [css] = await generateFontFallbacks('Some Unresolvable Font', {
+      src: [{ url: '/unreadable.woff2' }],
+      metrics: { unitsPerEm: 1000, ascent: 1000, descent: -250, lineGap: 0, xWidthAvg: 500 },
+    } as never, [
+      { name: 'Some Unresolvable Font Fallback: Arial', font: 'Arial' },
+    ])
+
+    expect(css).toContain('font-family: "Some Unresolvable Font Fallback: Arial"')
+    expect(css).toContain('ascent-override: 89.1602%')
+    expect(css).toContain('descent-override: 22.29%')
+    expect(css).toContain('size-adjust: 112.1577%')
+  })
+
+  it('should leave `size-adjust` alone when the provider reports no average width', async () => {
+    const [css] = await generateFontFallbacks('Some Unresolvable Font', {
+      src: [{ url: '/unreadable.woff2' }],
+      metrics: { unitsPerEm: 1000, ascent: 1000, descent: -250, lineGap: 0 },
+    } as never, [
+      { name: 'Some Unresolvable Font Fallback: Arial', font: 'Arial' },
+    ])
+
+    expect(css).toContain('size-adjust: 100%')
+    expect(css).toContain('ascent-override: 100%')
+  })
+
+  it('should complete partial provider metrics from the metrics database', async () => {
+    const [ascentFromProvider] = await generateFontFallbacks('Inter', {
+      src: [{ url: '/unreadable.woff2' }],
+      metrics: { unitsPerEm: 2000, ascent: 2000 },
+    } as never, [
+      { name: 'Inter Fallback: Arial', font: 'Arial' },
+    ])
+
+    expect(ascentFromProvider).toContain('ascent-override: 93.3538%')
+    expect(ascentFromProvider).toContain('descent-override: 22.518%')
+
+    const [descentFromProvider] = await generateFontFallbacks('Inter', {
+      src: [{ url: '/unreadable.woff2' }],
+      metrics: { unitsPerEm: 2000, descent: -500 },
+    } as never, [
+      { name: 'Inter Fallback: Arial', font: 'Arial' },
+    ])
+
+    expect(descentFromProvider).toContain('descent-override: 23.3384%')
+  })
+
+  it('should ignore provider metrics that cannot produce fallback descriptors', async () => {
+    for (const metrics of [
+      null,
+      'nope',
+      {},
+      { unitsPerEm: 0, ascent: 1000, descent: -250, lineGap: 0 },
+      { unitsPerEm: 1000, ascent: 1000, capHeight: 700, xHeight: 500 },
+    ]) {
+      expect(await generateFontFallbacks('Some Unresolvable Font', { src: [{ url: '/unreadable.woff2' }], metrics } as never, [
+        { name: 'Some Unresolvable Font Fallback: Arial', font: 'Arial' },
+      ])).toEqual([])
+    }
   })
 })
 

--- a/packages/fontless/test/render.spec.ts
+++ b/packages/fontless/test/render.spec.ts
@@ -172,6 +172,9 @@ describe('generateFontFallbacks', () => {
       'nope',
       {},
       { unitsPerEm: 0, ascent: 1000, descent: -250, lineGap: 0 },
+      { unitsPerEm: -1000, ascent: 1000, descent: -250, lineGap: 0 },
+      { unitsPerEm: Number.POSITIVE_INFINITY, ascent: 1000, descent: -250, lineGap: 0 },
+      { unitsPerEm: 1000, ascent: Number.NaN, descent: -250, lineGap: 0 },
       { unitsPerEm: 1000, ascent: 1000, capHeight: 700, xHeight: 500 },
     ]) {
       expect(await generateFontFallbacks('Some Unresolvable Font', { src: [{ url: '/unreadable.woff2' }], metrics } as never, [

--- a/packages/fontless/test/resolve.spec.ts
+++ b/packages/fontless/test/resolve.spec.ts
@@ -852,6 +852,82 @@ describe('createResolver', () => {
       })
     })
 
+    it('should apply metric overrides to resolved faces', async () => {
+      const provider = createEmptyProvider('test', { fonts: [{ src: [{ url: '/font.woff2' }] }] })
+
+      const resolver = await createResolver({
+        options: { providers: { test: provider } },
+        providers: { test: provider },
+        normalizeFontData: defaultNormalizeFontData,
+      })
+
+      const overrides = {
+        ascentOverride: '90%',
+        descentOverride: '20%',
+        lineGapOverride: '0%',
+        sizeAdjust: '105%',
+      }
+
+      for (const override of [{ name: 'Inter', provider: 'test', ...overrides }, { name: 'Inter', ...overrides }]) {
+        const result = await resolver('Inter', override)
+        expect(result?.fonts?.[0]).toMatchObject(overrides)
+      }
+    })
+
+    it('should override metric descriptors returned by a provider', async () => {
+      const provider = createEmptyProvider('test', { fonts: [{ src: [{ url: '/font.woff2' }], sizeAdjust: '50%' } as never] })
+
+      const resolver = await createResolver({
+        options: { providers: { test: provider } },
+        providers: { test: provider },
+        normalizeFontData: defaultNormalizeFontData,
+      })
+
+      const result = await resolver('Inter', { name: 'Inter', sizeAdjust: '105%' })
+
+      expect(result?.fonts?.[0]).toMatchObject({ sizeAdjust: '105%' })
+    })
+
+    it('should leave provider metric descriptors in place when none are set', async () => {
+      const provider = createEmptyProvider('test', { fonts: [{ src: [{ url: '/font.woff2' }], sizeAdjust: '50%' } as never] })
+
+      const resolver = await createResolver({
+        options: { providers: { test: provider } },
+        providers: { test: provider },
+        normalizeFontData: defaultNormalizeFontData,
+      })
+
+      const result = await resolver('Inter', { name: 'Inter', display: 'optional' })
+
+      expect(result?.fonts?.[0]).toMatchObject({ sizeAdjust: '50%', display: 'optional' })
+    })
+
+    it('should apply metric overrides to a manually declared family', async () => {
+      const { provider } = createTrackingProvider('test')
+
+      const resolver = await createResolver({
+        options: { providers: { test: provider } },
+        providers: { test: provider },
+        normalizeFontData: defaultNormalizeFontData,
+      })
+
+      const result = await resolver('CustomFont', {
+        name: 'CustomFont',
+        src: '/custom.woff2',
+        ascentOverride: '90%',
+        descentOverride: '20%',
+        lineGapOverride: '0%',
+        sizeAdjust: '105%',
+      })
+
+      expect(result?.fonts?.[0]).toMatchObject({
+        ascentOverride: '90%',
+        descentOverride: '20%',
+        lineGapOverride: '0%',
+        sizeAdjust: '105%',
+      })
+    })
+
     it('should pass all descriptors through for a manually declared family', async () => {
       const { provider } = createTrackingProvider('test')
 


### PR DESCRIPTION
resolves https://github.com/nuxt/fonts/issues/421

### 📚 Description

there's currently no way to set a metric override on the primary `@font-face` we generate for a family, only on the fallback faces `fontaine` derives:

```ts
fonts: {
  families: [
    { name: 'My Font', src: '/my-font.woff2', descentOverride: '20%' },
  ],
}
```

this PR adds `ascentOverride`, `descentOverride`, `lineGapOverride` and `sizeAdjust` as family-level descriptors, applied to every face resolved for the family and rendered by `generateFontFace`, following what we already do for `display` and `unicodeRange`.

when unjs/unifont#499 merges, we won't need to recompute metrics for `fontshare` fonts

### 🚧 TODO
- [ ] merge unjs/unifont#499 and bump version
- [ ] drop the local `ProviderFontMetrics` type and the cast

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added font metric overrides for ascent, descent, line gap, and size adjustment.
  * Added glyph subsetting options with automatic Unicode range generation.
  * Added metric override support for resolved and manually declared font families.
  * Improved fallback font generation using provider metrics, supplemented by database metrics when needed.

* **Bug Fixes**
  * Invalid or incomplete provider metrics no longer produce unusable fallback font faces.

* **Tests**
  * Added coverage for subsetting, metric descriptors, fallback calculations, and override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->